### PR TITLE
Rename supported components

### DIFF
--- a/j5/backends/base.py
+++ b/j5/backends/base.py
@@ -28,7 +28,7 @@ class BackendMeta(ABCMeta):
                 if cls.board in cls.environment.supported_boards:
                     raise RuntimeError("You cannot register multiple backends for the same board in the same Environment.")  # noqa: E501
 
-                for component in cls.board.supported_components():
+                for component in cls.board.components():
                     if not issubclass(cls, component.interface_class()):
                         raise TypeError("The backend class doesn't have a required interface.")  # noqa: E501
 

--- a/j5/boards/base.py
+++ b/j5/boards/base.py
@@ -33,7 +33,7 @@ class Board(metaclass=ABCMeta):
 
     @staticmethod
     @abstractmethod
-    def supported_components():
+    def components():
         """The components on this board."""
         raise NotImplementedError  # pragma: no cover
 

--- a/j5/boards/j5/demo.py
+++ b/j5/boards/j5/demo.py
@@ -27,7 +27,7 @@ class DemoBoard(Board):
 
     @staticmethod
     def components():
-        """List the components that this Board supports."""
+        """List the components on this Board."""
         return[LED]
 
     @staticmethod

--- a/j5/boards/j5/demo.py
+++ b/j5/boards/j5/demo.py
@@ -26,7 +26,7 @@ class DemoBoard(Board):
         return self._serial
 
     @staticmethod
-    def supported_components():
+    def components():
         """List the components that this Board supports."""
         return[LED]
 

--- a/tests/backends/test_base.py
+++ b/tests/backends/test_base.py
@@ -21,7 +21,7 @@ class TestBoard(Board):
 
     @staticmethod
     def components():
-        """List the components that this Board supports."""
+        """List the components on this Board."""
         return []
 
     @staticmethod
@@ -45,7 +45,7 @@ class Test2Board(Board):
 
     @staticmethod
     def components():
-        """List the components that this Board supports."""
+        """List the components on this Board."""
         return []
 
     @staticmethod

--- a/tests/backends/test_base.py
+++ b/tests/backends/test_base.py
@@ -20,7 +20,7 @@ class TestBoard(Board):
         return "TEST"
 
     @staticmethod
-    def supported_components():
+    def components():
         """List the components that this Board supports."""
         return []
 
@@ -44,7 +44,7 @@ class Test2Board(Board):
         return "TEST2"
 
     @staticmethod
-    def supported_components():
+    def components():
         """List the components that this Board supports."""
         return []
 

--- a/tests/boards/test_base.py
+++ b/tests/boards/test_base.py
@@ -20,7 +20,7 @@ class TestingBoard(Board):
 
     @staticmethod
     def components():
-        """List the components that this Board supports."""
+        """List the components on this Board."""
         return []
 
     @staticmethod

--- a/tests/boards/test_base.py
+++ b/tests/boards/test_base.py
@@ -19,7 +19,7 @@ class TestingBoard(Board):
         return "SERIAL"
 
     @staticmethod
-    def supported_components():
+    def components():
         """List the components that this Board supports."""
         return []
 

--- a/tests/components/test_led.py
+++ b/tests/components/test_led.py
@@ -30,7 +30,7 @@ class TestingLEDBoard(Board):
         return "SERIAL"
 
     @property
-    def supported_components(self):
+    def components(self):
         """List the components that this Board supports."""
         return [LED]
 


### PR DESCRIPTION
After discussion with @RealOrangeOne and @trickeydan, removing `supported` from the variable name seemed to make more sense