### PR TITLE
Revert "Rename supported_components to components"

### DIFF
--- a/j5/backends/base.py
+++ b/j5/backends/base.py
@@ -31,7 +31,7 @@ class BackendMeta(ABCMeta):
                 if cls.board in cls.environment.supported_boards:
                     raise RuntimeError("You cannot register multiple backends for the same board in the same Environment.")  # noqa: E501
 
-                for component in cls.board.components():
+                for component in cls.board.supported_components():
                     if not issubclass(cls, component.interface_class()):
                         raise TypeError("The backend class doesn't have a required interface.")  # noqa: E501
 

--- a/j5/boards/base.py
+++ b/j5/boards/base.py
@@ -37,8 +37,8 @@ class Board(metaclass=ABCMeta):
 
     @staticmethod
     @abstractmethod
-    def components() -> List[Type['Component']]:
-        """The components on this board."""
+    def supported_components() -> List[Type['Component']]:
+        """The types of component supported by this board."""
         raise NotImplementedError  # pragma: no cover
 
     @staticmethod

--- a/j5/boards/j5/demo.py
+++ b/j5/boards/j5/demo.py
@@ -33,8 +33,8 @@ class DemoBoard(Board):
         return self._serial
 
     @staticmethod
-    def components() -> List['Type[Component]']:
-        """List the components on this Board."""
+    def supported_components() -> List['Type[Component]']:
+        """List the types of component supported by this Board."""
         return [LED]
 
     @staticmethod

--- a/tests/backends/test_base.py
+++ b/tests/backends/test_base.py
@@ -20,8 +20,8 @@ class TestBoard(Board):
         return "TEST"
 
     @staticmethod
-    def components():
-        """List the components on this Board."""
+    def supported_components():
+        """List the types of component supported by this Board."""
         return []
 
     @staticmethod
@@ -44,8 +44,8 @@ class Test2Board(Board):
         return "TEST2"
 
     @staticmethod
-    def components():
-        """List the components on this Board."""
+    def supported_components():
+        """List the types of component supported by this Board."""
         return []
 
     @staticmethod

--- a/tests/boards/test_base.py
+++ b/tests/boards/test_base.py
@@ -19,8 +19,8 @@ class TestingBoard(Board):
         return "SERIAL"
 
     @staticmethod
-    def components():
-        """List the components on this Board."""
+    def supported_components():
+        """List the types of component supported by this Board."""
         return []
 
     @staticmethod

--- a/tests/components/test_led.py
+++ b/tests/components/test_led.py
@@ -30,8 +30,8 @@ class TestingLEDBoard(Board):
         return "SERIAL"
 
     @property
-    def components(self):
-        """List the components that this Board supports."""
+    def supported_components(self):
+        """List the types of component that this Board supports."""
         return [LED]
 
     @staticmethod


### PR DESCRIPTION
This reverts commit aa4f448a8096069c3115065c11627e61acd76533.

`components` would imply that the function returns every component
instance on the board, instead of the classes of component that
are supported by the board. `supported_components` better describes
what this function does.

This also updates the docstrings associated with the function to be clearer.