### PR TITLE
Ensure board's are setup by overriding __new__

### DIFF
--- a/j5/boards/base.py
+++ b/j5/boards/base.py
@@ -27,14 +27,14 @@ class Board(metaclass=ABCMeta):
     def __new__(cls, *args, **kwargs):
         """Ensure any instantiated board is correctly setup."""
         instance = super().__new__(cls)
-        instance.setup()
+        instance._setup()
         return instance
 
     def __repr__(self) -> str:
         """A representation of this board."""
         return f"<{self.__class__.__name__} serial={self.serial}>"
 
-    def setup(self):
+    def _setup(self):
         """
         Setup the board.
 

--- a/j5/boards/base.py
+++ b/j5/boards/base.py
@@ -25,27 +25,14 @@ class Board(metaclass=ABCMeta):
         return f"{self.name} - {self.serial}"
 
     def __new__(cls, *args, **kwargs):
-        """Ensure any instantiated board is correctly setup."""
+        """Ensure any instantiated board is added to the boards list."""
         instance = super().__new__(cls)
-        instance._board_setup = False
-        instance._setup()
+        Board.BOARDS.append(instance)
         return instance
 
     def __repr__(self) -> str:
         """A representation of this board."""
         return f"<{self.__class__.__name__} serial={self.serial}>"
-
-    def _setup(self):
-        """
-        Setup the board.
-
-        Adds the implementation to BOARDS.
-        """
-        if not self._board_setup:
-            Board.BOARDS.append(self)
-            self._board_setup = True
-        else:
-            raise Exception(f"Setup has already been called for board {self.serial}")
 
     @property
     @abstractmethod

--- a/j5/boards/base.py
+++ b/j5/boards/base.py
@@ -24,6 +24,12 @@ class Board(metaclass=ABCMeta):
         """A string representation of this board."""
         return f"{self.name} - {self.serial}"
 
+    def __new__(cls, *args, **kwargs):
+        """Ensure any instantiated board is correctly setup."""
+        instance = super().__new__(cls)
+        instance.setup()
+        return instance
+
     def __repr__(self) -> str:
         """A representation of this board."""
         return f"<{self.__class__.__name__} serial={self.serial}>"

--- a/j5/boards/base.py
+++ b/j5/boards/base.py
@@ -27,6 +27,7 @@ class Board(metaclass=ABCMeta):
     def __new__(cls, *args, **kwargs):
         """Ensure any instantiated board is correctly setup."""
         instance = super().__new__(cls)
+        instance._board_setup = False
         instance._setup()
         return instance
 
@@ -40,7 +41,11 @@ class Board(metaclass=ABCMeta):
 
         Adds the implementation to BOARDS.
         """
-        Board.BOARDS.append(self)
+        if not self._board_setup:
+            Board.BOARDS.append(self)
+            self._board_setup = True
+        else:
+            raise Exception(f"Setup has already been called for board {self.serial}")
 
     @property
     @abstractmethod

--- a/j5/boards/j5/demo.py
+++ b/j5/boards/j5/demo.py
@@ -16,7 +16,6 @@ class DemoBoard(Board):
     """A board for demo purposes, containing 3 LEDs."""
 
     def __init__(self, serial: str, environment: Environment):
-        self.setup()
         self._environment = environment
         self._backend = environment.get_backend(self.__class__)
         self._serial = serial

--- a/tests/backends/test_base.py
+++ b/tests/backends/test_base.py
@@ -9,9 +9,6 @@ from j5.boards import Board
 class MockBoard(Board):
     """A test board."""
 
-    def __init__(self):
-        self.setup()
-
     @property
     def name(self) -> str:
         """The name of the board."""
@@ -39,9 +36,6 @@ class MockBoard(Board):
 
 class Mock2Board(Board):
     """A test board."""
-
-    def __init__(self):
-        self.setup()
 
     @property
     def name(self) -> str:

--- a/tests/boards/test_base.py
+++ b/tests/boards/test_base.py
@@ -134,21 +134,10 @@ def test_discover():
     assert MockBoard.discover(NoBoardMockBackend()) == []
 
 
-def test_testing_board_setup():
-    """Test that a board is correctly marked as setup."""
+def test_testing_board_added_to_boards_list():
+    """Test that an instantiated board is added to the boards list."""
     board = MockBoard()
-    assert board._board_setup
-
-
-def test_testing_board_setup_throw_when_called_twice():
-    """Test that a board raises an exception if setup multiple times."""
-    board = MockBoard()
-    assert board._board_setup
-    with pytest.raises(Exception) as exec_info:
-        board._setup()
-
-    # Check that the boards serial number is in the error message
-    assert board.serial in exec_info.value.args[0]
+    assert board in Board.BOARDS
 
 
 def test_create_boardgroup():

--- a/tests/boards/test_base.py
+++ b/tests/boards/test_base.py
@@ -134,6 +134,23 @@ def test_discover():
     assert MockBoard.discover(NoBoardMockBackend()) == []
 
 
+def test_testing_board_setup():
+    """Test that a board is correctly marked as setup."""
+    board = MockBoard()
+    assert board._board_setup
+
+
+def test_testing_board_setup_throw_when_called_twice():
+    """Test that a board raises an exception if setup multiple times."""
+    board = MockBoard()
+    assert board._board_setup
+    with pytest.raises(Exception) as exec_info:
+        board._setup()
+
+    # Check that the boards serial number is in the error message
+    assert board.serial in exec_info.value.args[0]
+
+
 def test_create_boardgroup():
     """Test that we can create a board group of testing boards."""
     board_group = BoardGroup(MockBoard, NoBoardMockBackend())

--- a/tests/boards/test_base.py
+++ b/tests/boards/test_base.py
@@ -8,9 +8,6 @@ from j5.boards.base import Board, BoardGroup, BoardIndex
 class MockBoard(Board):
     """A testing board with little to no functionality."""
 
-    def __init__(self):
-        self.setup()
-
     @property
     def name(self) -> str:
         """Get the name of this board."""
@@ -34,6 +31,15 @@ class MockBoard(Board):
     def discover(backend: Backend):
         """Detect all boards of this type that are attached."""
         return backend.get_testing_boards()
+
+
+class MockBoardWithConstructor(MockBoard):
+    """A testing board with a constructor."""
+
+    def __init__(self, test_param, another_param, one_that_defaults=True):
+        self.test_param = test_param
+        self.another_param = another_param
+        self.one_that_defaults = one_that_defaults
 
 
 class NoBoardMockBackend(Backend):
@@ -83,6 +89,14 @@ def test_board_index():
 def test_testing_board_instantiation():
     """Test that we can instantiate the testing board."""
     MockBoard()
+
+
+def test_testing_board_instantiation_with_constructor():
+    """Test that we can instantiate a board that has a constructor."""
+    board = MockBoardWithConstructor("test", another_param="test2")
+    assert board.test_param == "test"
+    assert board.another_param == "test2"
+    assert board.one_that_defaults is True
 
 
 def test_testing_board_name():

--- a/tests/components/test_led.py
+++ b/tests/components/test_led.py
@@ -19,9 +19,6 @@ class MockLEDDriver(LEDInterface):
 class MockLEDBoard(Board):
     """A testing board for the led."""
 
-    def __init__(self):
-        self.setup()
-
     @property
     def name(self) -> str:
         """The name of this board."""


### PR DESCRIPTION
This PR overrides the `__new__` method of `Board` to ensure that all instances have `.setup()` called on them.

I have also added a test to ensure that a `Board` can be correctly instantiated using all methods of variable declaration (positional, keyword arg and default). Happy for this to be removed if this is felt to be excessive.

There is also now the question of should `.setup()` be made "private" to discourage consumers from calling it?

All feedback welcome.

Closes #28 