### PR TITLE
Tighten up mypy config

### DIFF
--- a/j5/backends/base.py
+++ b/j5/backends/base.py
@@ -15,7 +15,7 @@ class BackendMeta(ABCMeta):
 
     """
 
-    def __new__(mcs, name, bases, namespace, **kwargs):
+    def __new__(mcs, name, bases, namespace, **kwargs):  # type:ignore
         """Create a new class object."""
         cls = super().__new__(mcs, name, bases, namespace, **kwargs)  # type: ignore
 
@@ -51,7 +51,7 @@ class Backend(metaclass=BackendMeta):
 
     @property
     @abstractmethod
-    def environment(self):
+    def environment(self) -> 'Environment':
         """Environment the backend belongs too."""
         raise NotImplementedError  # pragma: no cover
 

--- a/j5/base_robot.py
+++ b/j5/base_robot.py
@@ -6,6 +6,6 @@ from j5.boards import Board
 class BaseRobot:
     """A base robot."""
 
-    def make_safe(self):
+    def make_safe(self) -> None:
         """Make this robot safe."""
         Board.make_all_safe()

--- a/j5/boards/base.py
+++ b/j5/boards/base.py
@@ -21,7 +21,7 @@ class Board(metaclass=ABCMeta):
         """A string representation of this board."""
         return f"{self.name} - {self.serial}"
 
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *args, **kwargs):  # type: ignore
         """Ensure any instantiated board is added to the boards list."""
         instance = super().__new__(cls)
         Board.BOARDS.append(instance)
@@ -44,7 +44,7 @@ class Board(metaclass=ABCMeta):
         raise NotImplementedError  # pragma: no cover
 
     @abstractmethod
-    def make_safe(self):
+    def make_safe(self) -> None:
         """Make all components on this board safe."""
         raise NotImplementedError  # pragma: no cover
 
@@ -62,7 +62,7 @@ class Board(metaclass=ABCMeta):
 
     @staticmethod
     @atexit.register
-    def make_all_safe():
+    def make_all_safe() -> None:
         """Make all boards safe."""
         for board in Board.BOARDS:
             board.make_safe()
@@ -91,9 +91,9 @@ class BoardGroup:
             return list(self.boards.values())[0]
         raise Exception("There is more than one or zero boards connected.")
 
-    def make_safe(self):
+    def make_safe(self) -> None:
         """Make all of the boards safe."""
-        for board in self.boards:
+        for board in self.boards.values():
             board.make_safe()
 
     def __len__(self) -> int:
@@ -115,7 +115,7 @@ class BoardGroup:
         self._iterator_counter += 1
         return board
 
-    def __getitem__(self, serial: str):
+    def __getitem__(self, serial: str) -> Board:
         """Get the board from serial."""
         try:
             return self.boards[serial]

--- a/j5/boards/j5/demo.py
+++ b/j5/boards/j5/demo.py
@@ -32,7 +32,7 @@ class DemoBoard(Board):
         """Get the serial number."""
         return self._serial
 
-    def make_safe(self):
+    def make_safe(self) -> None:
         """Make this board safe."""
         pass
 

--- a/j5/components/__init__.py
+++ b/j5/components/__init__.py
@@ -1,6 +1,6 @@
 """This module contains components, which are the smallest logical element of hardware."""
 
-from .base import Component
+from .base import Component, Interface
 from .led import LED, LEDInterface
 
-__all__ = ["Component", "LED", "LEDInterface"]
+__all__ = ["Component", "LED", "LEDInterface", "Interface"]

--- a/j5/components/__init__.py
+++ b/j5/components/__init__.py
@@ -4,4 +4,4 @@ from .base import Component, Interface
 from .button import Button, ButtonInterface
 from .led import LED, LEDInterface
 
-__all__ = ["Component", "Button", "ButtonInterface","Interface", "LED", "LEDInterface"]
+__all__ = ["Component", "Button", "ButtonInterface", "Interface", "LED", "LEDInterface"]

--- a/j5/components/base.py
+++ b/j5/components/base.py
@@ -1,11 +1,11 @@
 """Base classes for components."""
 
-from typing import Type
 from abc import ABCMeta, abstractmethod
+from typing import Type
 
 
 class Interface(metaclass=ABCMeta):
-    """A small useless class"""
+    """A base class for interfaces to inherit from"""
 
 
 class Component(metaclass=ABCMeta):

--- a/j5/components/base.py
+++ b/j5/components/base.py
@@ -5,7 +5,7 @@ from typing import Type
 
 
 class Interface(metaclass=ABCMeta):
-    """A base class for interfaces to inherit from"""
+    """A base class for interfaces to inherit from."""
 
 
 class Component(metaclass=ABCMeta):

--- a/j5/components/base.py
+++ b/j5/components/base.py
@@ -1,6 +1,11 @@
 """Base classes for components."""
 
+from typing import Type
 from abc import ABCMeta, abstractmethod
+
+
+class Interface(metaclass=ABCMeta):
+    """A small useless class"""
 
 
 class Component(metaclass=ABCMeta):
@@ -8,6 +13,6 @@ class Component(metaclass=ABCMeta):
 
     @staticmethod
     @abstractmethod
-    def interface_class():
+    def interface_class() -> Type[Interface]:
         """Get the interface class that is required to use this component."""
         raise NotImplementedError  # pragma: no cover

--- a/j5/components/battery_sensor.py
+++ b/j5/components/battery_sensor.py
@@ -1,6 +1,6 @@
 """Classes for Battery Sensing Components."""
 
-from abc import ABCMeta, abstractmethod
+from abc import abstractmethod
 from typing import Type
 
 from j5.boards import Board

--- a/j5/components/battery_sensor.py
+++ b/j5/components/battery_sensor.py
@@ -4,10 +4,10 @@ from abc import ABCMeta, abstractmethod
 from typing import Type
 
 from j5.boards import Board
-from j5.components import Component
+from j5.components import Component, Interface
 
 
-class BatterySensorInterface(metaclass=ABCMeta):
+class BatterySensorInterface(Interface):
     """An interface containing the methods required to read data from a BatterySensor."""
 
     @abstractmethod

--- a/j5/components/button.py
+++ b/j5/components/button.py
@@ -1,12 +1,13 @@
 """Classes for Button."""
 
-from abc import ABCMeta, abstractmethod
+from abc import abstractmethod
+from typing import Type
 
 from j5.boards import Board
-from j5.components import Component
+from j5.components import Component, Interface
 
 
-class ButtonInterface(metaclass=ABCMeta):
+class ButtonInterface(Interface):
     """An interface containing the methods required for a button."""
 
     @abstractmethod
@@ -29,7 +30,7 @@ class Button(Component):
         self._identifier = identifier
 
     @staticmethod
-    def interface_class():
+    def interface_class() -> Type[ButtonInterface]:
         """Get the interface class that is required to use this component."""
         return ButtonInterface
 
@@ -38,6 +39,6 @@ class Button(Component):
         """Get the current pushed state of the button."""
         return self._backend.get_button_state(self._board, self._identifier)
 
-    def wait_until_pressed(self):
+    def wait_until_pressed(self) -> None:
         """Halt the program until this button is pushed."""
         self._backend.wait_until_button_pressed(self._board, self._identifier)

--- a/j5/components/led.py
+++ b/j5/components/led.py
@@ -1,10 +1,10 @@
 """Classes for the LED support."""
 
 from abc import abstractmethod
+from typing import Type
 
 from j5.boards import Board
 from j5.components import Component, Interface
-from typing import Type
 
 
 class LEDInterface(Interface):

--- a/j5/components/led.py
+++ b/j5/components/led.py
@@ -1,12 +1,13 @@
 """Classes for the LED support."""
 
-from abc import ABCMeta, abstractmethod
+from abc import abstractmethod
 
 from j5.boards import Board
-from j5.components import Component
+from j5.components import Component, Interface
+from typing import Type
 
 
-class LEDInterface(metaclass=ABCMeta):
+class LEDInterface(Interface):
     """An interface containing the methods required to control an LED."""
 
     @abstractmethod
@@ -29,7 +30,7 @@ class LED(Component):
         self._identifier = identifier
 
     @staticmethod
-    def interface_class():
+    def interface_class() -> Type[LEDInterface]:
         """Get the interface class that is required to use this component."""
         return LEDInterface
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,9 +29,23 @@ sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 
 [mypy]
 warn_unused_ignores = True
-strict_optional = True
+warn_return_any = True
 
+strict_optional = True
+no_implicit_optional = True
+
+disallow_any_unimported = True
+#disallow_any_expr = True
+#disallow_any_decorated = True
+disallow_any_explicit = True
+disallow_subclassing_any = True
 disallow_any_generics = True
+
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+disallow_untyped_decorators = True
+
 check_untyped_defs = True
 
-ignore_missing_imports = True
+ignore_missing_imports = False


### PR DESCRIPTION
Fixes #68.

Have had to add a base `Interface` class to appease the `disallow_any_generics` flag.

Two flags are currently disabled as they cause errors where we use `atexit` and `__new__`, eager to discuss what we should do here.

Unrelated `pipenv run lint` gives a different result locally to that on CI. Almost certain this is something wrong with my local Windows setup, but will investigate and open new issue if necessary