### PR TITLE
Ensure that Pipfile.lock is kept up to date

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - checkout
       - run: pip install pipenv
-      - run: pipenv install --dev
+      - run: pipenv install --deploy --dev
       - run:
           name: Setup Code Climate test-reporter
           command: |


### PR DESCRIPTION
This is done by passing `--deploy` to `pipenv install` during the CircleCI script, which is documented to "abort if the Pipfile.lock is out-of-date, or Python version is wrong". The aim is to ensure
that the versions of Pipfile and Pipfile.lock in the repository are kept consistent.

Tested by adding a new package (`numpy`, arbitrarily) to the list of dependencies in the Pipfile and running a CircleCI build, which results in an error as expected:

    Your Pipfile.lock (e6a0f9) is out of date. Expected: (938333)

Before this commit, the same action would cause `pipenv install` to regenerate Pipfile.lock and install the spurious package - however the version of this package is not locked by the Pipfile.lock
committed in the repository.

I could be a kernel hacker with commit messages like this...