### PR TITLE
Use pipenv sync in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - checkout
       - run: pip install pipenv
-      - run: pipenv install --dev
+      - run: pipenv sync --dev
       - run:
           name: Setup Code Climate test-reporter
           command: |


### PR DESCRIPTION
This ensures the CI installs exactly what is specified in `Pipfile.lock`,
without regenerating the file from `Pipfile`. As a result, builds
shouldn't spontaneously start breaking as a result of new versions
of dependent packages being released.