### PR TITLE
Use j5api/ci docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,19 +2,12 @@ version: 2
 jobs:
   build:
     docker:
-      - image: python:3.7
+      - image: j5api/ci:latest
     steps:
       - checkout
-      - run: pip install pipenv
       - run: pipenv sync --dev
-      - run:
-          name: Setup Code Climate test-reporter
-          command: |
-            # download test reporter as a static binary
-                     curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-                     chmod +x ./cc-test-reporter
       - run: pipenv run lint
       - run: pipenv run type
-      - run: ./cc-test-reporter before-build
+      - run: cc-test-reporter before-build
       - run: pipenv run test-ci
-      - run: ./cc-test-reporter after-build -t coverage.py --exit-code $? coverage.xml
+      - run: cc-test-reporter after-build -t coverage.py --exit-code $? coverage.xml


### PR DESCRIPTION
This docker image encapsulates the parts of the CI process that
do not depend on the contents of the repository. The image is
defined in https://github.com/j5api/docker-ci and is automatically
built and pushed by Docker Hub whenever the docker-ci git
repository is pushed to.

Reviewers, please consider the current contents of https://github.com/j5api/docker-ci as part of the code to be reviewed here.