### PR TITLE
Add Nix environment definition

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,16 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+# Note that as of 2019-01-21, pipenv is currently broken in the NixOS 18.09 release.
+# https://github.com/NixOS/nixpkgs/issues/51970
+# To work around, invoke with:
+# nix-shell -E 'import ./shell.nix { pkgs = import (fetchTarball https://nixos.org/channels/nixpkgs-unstable/nixexprs.tar.xz) {}; }'
+
+with pkgs;
+
+stdenv.mkDerivation {
+  name = "j5-dev-env";
+  buildInputs = [
+    pipenv
+    python3
+  ];
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,13 @@
+# A nixpkgs overlay to set python3Packages to python37Packages (the default is python36Packages).
+let
+  python37ByDefault = self: super: {
+    python3Packages = self.python37Packages;
+  };
+in
+
 {
   pkgsSrc ? <nixpkgs>,
-  pkgs ? import pkgsSrc {}
+  pkgs ? import pkgsSrc { overlays = [python37ByDefault]; },
 }:
 
 # Note that as of 2019-01-21, pipenv is currently broken in the NixOS 18.09 release.

--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,12 @@
-{ pkgs ? import <nixpkgs> {} }:
+{
+  pkgsSrc ? <nixpkgs>,
+  pkgs ? import pkgsSrc {}
+}:
 
 # Note that as of 2019-01-21, pipenv is currently broken in the NixOS 18.09 release.
 # https://github.com/NixOS/nixpkgs/issues/51970
 # To work around, invoke with:
-# nix-shell -E 'import ./shell.nix { pkgs = import (fetchTarball https://nixos.org/channels/nixpkgs-unstable/nixexprs.tar.xz) {}; }'
+# nix-shell -E 'import ./shell.nix { pkgsSrc = fetchTarball https://nixos.org/channels/nixpkgs-unstable/nixexprs.tar.xz; }'
 
 with pkgs;
 


### PR DESCRIPTION
This enables [Nix](https://nixos.org/nix/) users to simply run `nix-shell` in the repository root to obtain a shell with python and pipenv (and anything else we may want to add in the future) available.