### PR TITLE
Add an abstract discover method to Backend

### DIFF
--- a/j5/backends/base.py
+++ b/j5/backends/base.py
@@ -49,6 +49,11 @@ class Backend(metaclass=BackendMeta):
 
     """
 
+    @classmethod
+    def discover(cls) -> List['Board']:
+        """Discover boards that this backend can control."""
+        raise NotImplementedError  # pragma: no cover
+
     @property
     @abstractmethod
     def environment(self) -> 'Environment':

--- a/j5/backends/base.py
+++ b/j5/backends/base.py
@@ -50,6 +50,7 @@ class Backend(metaclass=BackendMeta):
     """
 
     @classmethod
+    @abstractmethod
     def discover(cls) -> List['Board']:
         """Discover boards that this backend can control."""
         raise NotImplementedError  # pragma: no cover

--- a/j5/backends/dummy/demo.py
+++ b/j5/backends/dummy/demo.py
@@ -1,4 +1,5 @@
 """Dummy Backends for the demo boards."""
+from typing import List
 
 from j5.backends import Backend
 from j5.backends.dummy.env import DummyEnvironment
@@ -20,3 +21,8 @@ class DemoBoardDummyBackend(LEDInterface, Backend):
     def get_led_state(self, board: Board, identifier: int) -> bool:
         """Get the state of an LED."""
         return False
+
+    @classmethod
+    def discover(cls) -> List[Board]:
+        """Discover boards available on this backend."""
+        return []

--- a/tests/backends/test_base.py
+++ b/tests/backends/test_base.py
@@ -1,8 +1,8 @@
 """Tests for the base backend classes."""
 
-import pytest
-
 from typing import List
+
+import pytest
 
 from j5.backends import Backend, Environment
 from j5.boards import Board
@@ -72,7 +72,6 @@ class MockBackend(Backend):
 
     environment = MockEnvironment
     board = MockBoard
-
 
     @classmethod
     def discover(cls) -> List[Board]:

--- a/tests/backends/test_base.py
+++ b/tests/backends/test_base.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from typing import List
+
 from j5.backends import Backend, Environment
 from j5.boards import Board
 
@@ -70,6 +72,12 @@ class MockBackend(Backend):
 
     environment = MockEnvironment
     board = MockBoard
+
+
+    @classmethod
+    def discover(cls) -> List[Board]:
+        """Discover boards available on this backend."""
+        return []
 
 
 def test_backend_instantiation():

--- a/tests/boards/j5/test_demo.py
+++ b/tests/boards/j5/test_demo.py
@@ -1,4 +1,6 @@
 """Test the demo board."""
+from typing import List
+
 from j5.backends import Backend, Environment
 from j5.boards import Board
 from j5.boards.j5 import DemoBoard
@@ -20,6 +22,11 @@ class MockDemoBoardBackend(LEDInterface, Backend):
     def get_led_state(self, board: Board, identifier: int) -> bool:
         """Get the current state of an LED."""
         return True
+
+    @classmethod
+    def discover(cls) -> List[Board]:
+        """Discover boards available on this backend."""
+        return []
 
 
 def test_demo_board_instantiation():

--- a/tests/boards/test_base.py
+++ b/tests/boards/test_base.py
@@ -1,6 +1,8 @@
 """Test the base classes for boards."""
 import pytest
 
+from typing import List
+
 from j5.backends import Backend, Environment
 from j5.boards.base import Board, BoardGroup
 
@@ -55,6 +57,11 @@ class NoBoardMockBackend(Backend):
         """Get the connected MockBoards."""
         return []
 
+    @classmethod
+    def discover(cls) -> List[Board]:
+        """Discover boards available on this backend."""
+        return []
+
 
 class OneBoardMockBackend(Backend):
     """This backend finds exactly one."""
@@ -66,6 +73,10 @@ class OneBoardMockBackend(Backend):
         """Get the connected MockBoards."""
         return [MockBoard("TESTSERIAL1")]
 
+    @classmethod
+    def discover(cls) -> List[Board]:
+        """Discover boards available on this backend."""
+        return []
 
 class TwoBoardsMockBackend(Backend):
     """This backend finds exactly two."""
@@ -79,6 +90,11 @@ class TwoBoardsMockBackend(Backend):
         # that sorting the boards (as tested by
         # test_board_group_iteration_sorted_by_serial) actually has an effect.
         return [MockBoard("TESTSERIAL2"), MockBoard("TESTSERIAL1")]
+
+    @classmethod
+    def discover(cls) -> List[Board]:
+        """Discover boards available on this backend."""
+        return []
 
 
 def test_testing_board_instantiation():

--- a/tests/boards/test_base.py
+++ b/tests/boards/test_base.py
@@ -1,7 +1,7 @@
 """Test the base classes for boards."""
-import pytest
-
 from typing import List
+
+import pytest
 
 from j5.backends import Backend, Environment
 from j5.boards.base import Board, BoardGroup
@@ -77,6 +77,7 @@ class OneBoardMockBackend(Backend):
     def discover(cls) -> List[Board]:
         """Discover boards available on this backend."""
         return []
+
 
 class TwoBoardsMockBackend(Backend):
     """This backend finds exactly two."""


### PR DESCRIPTION
This ensures that board discovery is implemented in the backend.

Also relevant is #103, which this method replaces.