### PR TITLE
Make PowerBoard take a backend as a constructor argument instead of a…

### DIFF
--- a/j5/boards/sr/v4/power_board.py
+++ b/j5/boards/sr/v4/power_board.py
@@ -3,7 +3,7 @@
 from enum import Enum
 from typing import TYPE_CHECKING, List, Mapping, cast
 
-from j5.backends import Backend, Environment
+from j5.backends import Backend
 from j5.boards import Board
 from j5.components import (
     LED,
@@ -44,11 +44,9 @@ class PowerOutputPosition(Enum):
 class PowerBoard(Board):
     """Student Robotics v4 Power Board."""
 
-    def __init__(self, serial: str, environment: Environment):
+    def __init__(self, serial: str, backend: Backend):
         self._serial = serial
-        self._environment = environment
-
-        self._backend = self._environment.get_backend(self.__class__)
+        self._backend = backend
 
         self._outputs: Mapping[PowerOutputPosition, PowerOutput] = {
             output: PowerOutput(

--- a/tests/boards/sr/v4/test_power_board.py
+++ b/tests/boards/sr/v4/test_power_board.py
@@ -85,38 +85,37 @@ class MockPowerBoardBackend(
 
 def test_power_board_instantiation():
     """Test that we can instantiate a PowerBoard."""
-    PowerBoard("SERIAL0", MockEnvironment)
+    PowerBoard("SERIAL0", MockPowerBoardBackend())
 
 
 def test_power_board_discover():
     """Test that we can discover PowerBoards."""
-    backend = MockEnvironment.get_backend(PowerBoard)
-    assert PowerBoard.discover(backend) == []
+    assert MockPowerBoardBackend.discover() == []
 
 
 def test_power_board_name():
     """Test the name attribute of the PowerBoard."""
-    pb = PowerBoard("SERIAL0", MockEnvironment)
+    pb = PowerBoard("SERIAL0", MockPowerBoardBackend())
 
     assert pb.name == "Student Robotics v4 Power Board"
 
 
 def test_power_board_serial():
     """Test the serial attribute of the PowerBoard."""
-    pb = PowerBoard("SERIAL0", MockEnvironment)
+    pb = PowerBoard("SERIAL0", MockPowerBoardBackend())
 
     assert pb.serial == "SERIAL0"
 
 
 def test_power_board_make_safe():
     """Test the make_safe method of the PowerBoard."""
-    pb = PowerBoard("SERIAL0", MockEnvironment)
+    pb = PowerBoard("SERIAL0", MockPowerBoardBackend())
     pb.make_safe()
 
 
 def test_power_board_outputs():
     """Test the power outputs on the PowerBoard."""
-    pb = PowerBoard("SERIAL0", MockEnvironment)
+    pb = PowerBoard("SERIAL0", MockPowerBoardBackend())
 
     assert type(pb.outputs) is PowerOutputGroup
     assert len(pb.outputs) == 6
@@ -124,34 +123,34 @@ def test_power_board_outputs():
 
 def test_power_board_piezo():
     """Test the Piezo on the PowerBoard."""
-    pb = PowerBoard("SERIAL0", MockEnvironment)
+    pb = PowerBoard("SERIAL0", MockPowerBoardBackend())
 
     assert type(pb.piezo) is Piezo
 
 
 def test_power_board_button():
     """Test the Button on the PowerBoard."""
-    pb = PowerBoard("SERIAL0", MockEnvironment)
+    pb = PowerBoard("SERIAL0", MockPowerBoardBackend())
 
     assert type(pb.start_button) is Button
 
 
 def test_power_board_battery_sensor():
     """Test the Battery Sensor on the Power Board."""
-    pb = PowerBoard("SERIAL0", MockEnvironment)
+    pb = PowerBoard("SERIAL0", MockPowerBoardBackend())
 
     assert type(pb.battery_sensor) is BatterySensor
 
 
 def test_power_board_run_led():
     """Test the run LED on the Power Board."""
-    pb = PowerBoard("SERIAL0", MockEnvironment)
+    pb = PowerBoard("SERIAL0", MockPowerBoardBackend())
 
     assert type(pb._run_led) is LED
 
 
 def test_power_board_error_led():
     """Test the error LED on the Power Board."""
-    pb = PowerBoard("SERIAL0", MockEnvironment)
+    pb = PowerBoard("SERIAL0", MockPowerBoardBackend())
 
     assert type(pb._error_led) is LED


### PR DESCRIPTION
…n environment

It is presumed that the `PowerBoard` will be instantiated by
`Backend.discover`, which will already have created a corresponding
`Backend` instance.

Should also clean up any fallout from #123.