### PR TITLE
Add Typing and Education Troves for PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,7 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Development Status :: 3 - Alpha",
+        "Typing :: Typed",
+        "Topic :: Education",
     ],
 )


### PR DESCRIPTION
Closes #144. I've also added `Topic :: Education` as I scrolled through the list and noticed that it is appropriate.