### PR TITLE
shell.nix: use a more up-to-date URL in workaround command

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -12,7 +12,7 @@ in
 
 # Note that as of 2019-03-11, poetry is not currently available in any nixpkgs release.
 # To work around, invoke with:
-# nix-shell --arg pkgsSrc 'fetchTarball https://nixos.org/channels/nixpkgs-unstable/nixexprs.tar.xz'
+# nix-shell --arg pkgsSrc 'fetchTarball https://github.com/NixOS/nixpkgs/archive/master.tar.gz'
 # It should appear in NixOS/nixpkgs 19.03.
 
 with pkgs;


### PR DESCRIPTION
@mildlyincompetent could you verify this new command works for you?