### PR TITLE
Add CONTRIBUTORS to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# j5 specific
+CONTRIBUTORS
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Fixes #192. We don't want to ship a generated file accidentally.