### PR TITLE
Typecheck the tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
             - pip-packages-
       - run: poetry install
       - run: poetry run flake8 j5 tests
-      - run: poetry run mypy j5
+      - run: poetry run mypy j5 tests
       - run: cc-test-reporter before-build
       - run: poetry run pytest --cov=j5 tests --cov-report xml
       - run: cc-test-reporter after-build -t coverage.py --exit-code $? coverage.xml

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ lint:
 	$(CMD) flake8 $(PYMODULE) tests
 
 type:
-	$(CMD) mypy $(PYMODULE)
+	$(CMD) mypy $(PYMODULE) tests
 
 test:
 	$(CMD) pytest --cov=$(PYMODULE) tests

--- a/stubs/pytest.pyi
+++ b/stubs/pytest.pyi
@@ -1,0 +1,15 @@
+"""
+Type stubs for pytest.
+
+Note that stubs are only written for the parts that we use.
+"""
+
+from typing import ContextManager, Type
+
+
+# This function actually has more arguments than are specified here, and the
+# context manager actually yields a _pytest._code.ExceptionInfo instead of None.
+# We don't use either of these features, so I don't think its worth including
+# them in our type stub. We can always change it later.
+def raises(exc_type: Type[Exception]) -> ContextManager[None]:
+    ...

--- a/tests/backends/hardware/sr/v4/test_power_board.py
+++ b/tests/backends/hardware/sr/v4/test_power_board.py
@@ -27,7 +27,7 @@ from j5.boards.sr.v4.power_board import PowerBoard, PowerOutputPosition
 from j5.components.piezo import Note
 
 
-def test_read_command():
+def test_read_command() -> None:
     """Test that ReadCommand behaves as expected."""
     rc = ReadCommand(1, 2)
 
@@ -38,7 +38,7 @@ def test_read_command():
     assert rc.data_len == 2
 
 
-def test_write_command():
+def test_write_command() -> None:
     """Test that WriteCommand behaves as expected."""
     wc = WriteCommand(1)
 
@@ -47,7 +47,7 @@ def test_write_command():
     assert wc.code == 1
 
 
-def test_cmd_read_output():
+def test_cmd_read_output() -> None:
     """Test that CMD_READ_OUTPUT works."""
     assert len(CMD_READ_OUTPUT) == 6
 
@@ -58,35 +58,35 @@ def test_cmd_read_output():
         assert command.data_len == 4
 
 
-def test_cmd_read_5vrail():
+def test_cmd_read_5vrail() -> None:
     """Test that the CMD_READ_5VRAIL."""
     assert type(CMD_READ_5VRAIL) is ReadCommand
     assert CMD_READ_5VRAIL.code == 6
     assert CMD_READ_5VRAIL.data_len == 4
 
 
-def test_cmd_read_battery():
+def test_cmd_read_battery() -> None:
     """Test that the CMD_READ_BATTERY."""
     assert type(CMD_READ_BATTERY) is ReadCommand
     assert CMD_READ_BATTERY.code == 7
     assert CMD_READ_BATTERY.data_len == 8
 
 
-def test_cmd_read_button():
+def test_cmd_read_button() -> None:
     """Test that the CMD_READ_BUTTON."""
     assert type(CMD_READ_BUTTON) is ReadCommand
     assert CMD_READ_BUTTON.code == 8
     assert CMD_READ_BUTTON.data_len == 4
 
 
-def test_cmd_read_fwver():
+def test_cmd_read_fwver() -> None:
     """Test that the CMD_READ_FWVER."""
     assert type(CMD_READ_FWVER) is ReadCommand
     assert CMD_READ_FWVER.code == 9
     assert CMD_READ_FWVER.data_len == 4
 
 
-def test_cmd_write_output():
+def test_cmd_write_output() -> None:
     """Test that CMD_WRITE_OUTPUT works."""
     assert len(CMD_WRITE_OUTPUT) == 6
 
@@ -96,32 +96,32 @@ def test_cmd_write_output():
         assert pos.value == command.code
 
 
-def test_cmd_write_runled():
+def test_cmd_write_runled() -> None:
     """Test that the CMD_WRITE_RUNLED."""
     assert type(CMD_WRITE_RUNLED) is WriteCommand
     assert CMD_WRITE_RUNLED.code == 6
 
 
-def test_cmd_write_errorled():
+def test_cmd_write_errorled() -> None:
     """Test that the CMD_WRITE_ERRORLED."""
     assert type(CMD_WRITE_ERRORLED) is WriteCommand
     assert CMD_WRITE_ERRORLED.code == 7
 
 
-def test_cmd_write_piezo():
+def test_cmd_write_piezo() -> None:
     """Test that the CMD_WRITE_PIEZO."""
     assert type(CMD_WRITE_PIEZO) is WriteCommand
     assert CMD_WRITE_PIEZO.code == 8
 
 
-def test_usb_communication_error():
+def test_usb_communication_error() -> None:
     """Test that USBCommunicationError works."""
     u = USBCommunicationError(usb.core.USBError("Test."))
     assert str(u) == "Test."
     assert issubclass(USBCommunicationError, Exception)
 
 
-def test_usb_error_handler_decorator():
+def test_usb_error_handler_decorator() -> None:
     """Test that the handle_usb_error decorator works."""
     @handle_usb_error
     def test_func():
@@ -256,7 +256,7 @@ def mock_find(
     return [MockUSBPowerBoardDevice(f"SERIAL{n}") for n in range(0, 4)]
 
 
-def test_backend_initialisation():
+def test_backend_initialisation() -> None:
     """Test that we can initialise a Backend."""
     device = MockUSBPowerBoardDevice("SERIAL0")
     backend = SRV4PowerBoardHardwareBackend(device)
@@ -270,7 +270,7 @@ def test_backend_initialisation():
     assert not any(backend._led_states.values())  # Check initially all false.
 
 
-def test_backend_discover():
+def test_backend_discover() -> None:
     """Test that the backend can discover boards."""
     found_boards = SRV4PowerBoardHardwareBackend.discover(find=mock_find)
 
@@ -278,7 +278,7 @@ def test_backend_discover():
     assert type(found_boards[0]) is PowerBoard
 
 
-def test_backend_cleanup():
+def test_backend_cleanup() -> None:
     """Test that the backend cleans things up properly."""
     device = MockUSBPowerBoardDevice("SERIAL0")
     backend = SRV4PowerBoardHardwareBackend(device)
@@ -286,7 +286,7 @@ def test_backend_cleanup():
     del backend
 
 
-def test_backend_firmware_version():
+def test_backend_firmware_version() -> None:
     """Test that we can get the firmware version."""
     device = MockUSBPowerBoardDevice("SERIAL0")
     backend = SRV4PowerBoardHardwareBackend(device)
@@ -294,14 +294,14 @@ def test_backend_firmware_version():
     assert backend.firmware_version == 3
 
 
-def test_backend_bad_firmware_version():
+def test_backend_bad_firmware_version() -> None:
     """Test that we can get the firmware version."""
     device = MockUSBPowerBoardDevice("SERIAL0", fw_version=2)
     with pytest.raises(NotImplementedError):
         SRV4PowerBoardHardwareBackend(device)
 
 
-def test_backend_serial_number():
+def test_backend_serial_number() -> None:
     """Test that we can get the serial number."""
     device = MockUSBPowerBoardDevice("SERIAL0")
     backend = SRV4PowerBoardHardwareBackend(device)
@@ -309,7 +309,7 @@ def test_backend_serial_number():
     assert backend.serial() == "SERIAL0"
 
 
-def test_backend_get_power_output_enabled():
+def test_backend_get_power_output_enabled() -> None:
     """Test that we can read the enable status of a PowerOutput."""
     device = MockUSBPowerBoardDevice("SERIAL0")
     backend = SRV4PowerBoardHardwareBackend(device)
@@ -321,7 +321,7 @@ def test_backend_get_power_output_enabled():
         backend.get_power_output_enabled(6)
 
 
-def test_backend_set_power_output_enabled():
+def test_backend_set_power_output_enabled() -> None:
     """Test that we can read the enable status of a PowerOutput."""
     device = MockUSBPowerBoardDevice("SERIAL0")
     backend = SRV4PowerBoardHardwareBackend(device)
@@ -333,7 +333,7 @@ def test_backend_set_power_output_enabled():
         backend.set_power_output_enabled(6, True)
 
 
-def test_backend_get_power_output_current():
+def test_backend_get_power_output_current() -> None:
     """Test that we can read the current on a PowerOutput."""
     device = MockUSBPowerBoardDevice("SERIAL0")
     backend = SRV4PowerBoardHardwareBackend(device)
@@ -345,7 +345,7 @@ def test_backend_get_power_output_current():
         backend.get_power_output_current(6)
 
 
-def test_backend_piezo_buzz():
+def test_backend_piezo_buzz() -> None:
     """Test that we can buzz the Piezo."""
     device = MockUSBPowerBoardDevice("SERIAL0")
     backend = SRV4PowerBoardHardwareBackend(device)
@@ -365,7 +365,7 @@ def test_backend_piezo_buzz():
         backend.buzz(1, timedelta(seconds=10), 0)
 
 
-def test_backend_get_button_state():
+def test_backend_get_button_state() -> None:
     """Test that we can get the button state."""
     device = MockUSBPowerBoardDevice("SERIAL0")
     backend = SRV4PowerBoardHardwareBackend(device)
@@ -376,7 +376,7 @@ def test_backend_get_button_state():
         backend.get_button_state(1)
 
 
-def test_backend_get_battery_sensor_voltage():
+def test_backend_get_battery_sensor_voltage() -> None:
     """Test that we can get the battery sensor voltage."""
     device = MockUSBPowerBoardDevice("SERIAL0")
     backend = SRV4PowerBoardHardwareBackend(device)
@@ -387,7 +387,7 @@ def test_backend_get_battery_sensor_voltage():
         backend.get_battery_sensor_voltage(1)
 
 
-def test_backend_get_battery_sensor_current():
+def test_backend_get_battery_sensor_current() -> None:
     """Test that we can get the battery sensor current."""
     device = MockUSBPowerBoardDevice("SERIAL0")
     backend = SRV4PowerBoardHardwareBackend(device)
@@ -398,7 +398,7 @@ def test_backend_get_battery_sensor_current():
         backend.get_battery_sensor_current(1)
 
 
-def test_backend_get_led_states():
+def test_backend_get_led_states() -> None:
     """Get the LED states."""
     device = MockUSBPowerBoardDevice("SERIAL0")
     backend = SRV4PowerBoardHardwareBackend(device)
@@ -409,7 +409,7 @@ def test_backend_get_led_states():
         backend.get_led_state(7)
 
 
-def test_backend_set_led_states():
+def test_backend_set_led_states() -> None:
     """Set the LED states."""
     device = MockUSBPowerBoardDevice("SERIAL0")
     backend = SRV4PowerBoardHardwareBackend(device)

--- a/tests/backends/hardware/sr/v4/test_power_board.py
+++ b/tests/backends/hardware/sr/v4/test_power_board.py
@@ -124,7 +124,7 @@ def test_usb_communication_error() -> None:
 def test_usb_error_handler_decorator() -> None:
     """Test that the handle_usb_error decorator works."""
     @handle_usb_error
-    def test_func():
+    def test_func() -> None:
         raise usb.core.USBError("Test")
 
     with pytest.raises(USBCommunicationError):
@@ -134,7 +134,7 @@ def test_usb_error_handler_decorator() -> None:
 class MockUSBContext:
     """This class mocks the behaviour of usb.core.Context."""
 
-    def dispose(self, device: "MockUSBPowerBoardDevice"):
+    def dispose(self, device: "MockUSBPowerBoardDevice") -> None:
         """Dispose of the device."""
         pass
 
@@ -247,7 +247,7 @@ class MockUSBPowerBoardDevice:
 
 
 def mock_find(
-    find_all=True, *, idVendor: int, idProduct: int,
+    find_all: bool = True, *, idVendor: int, idProduct: int,
 ) -> List[MockUSBPowerBoardDevice]:
     """This function mocks the behaviour of usb.core.find."""
     assert idVendor == 0x1BDA

--- a/tests/backends/hardware/test_env.py
+++ b/tests/backends/hardware/test_env.py
@@ -4,7 +4,7 @@ from j5.backends import Environment
 from j5.backends.hardware import HardwareEnvironment
 
 
-def test_hardware_environment():
+def test_hardware_environment() -> None:
     """Test that the Hardware Environment works."""
     assert isinstance(HardwareEnvironment, Environment)
     assert HardwareEnvironment.name == "HardwareEnvironment"

--- a/tests/backends/test_backend.py
+++ b/tests/backends/test_backend.py
@@ -1,11 +1,14 @@
 """Tests for the base backend classes."""
 
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional, Type
 
 import pytest
 
 from j5.backends import Backend, Environment
 from j5.boards import Board
+
+if TYPE_CHECKING:  # pragma: nocover
+    from j5.components import Component  # noqa
 
 
 class MockBoard(Board):

--- a/tests/backends/test_backend.py
+++ b/tests/backends/test_backend.py
@@ -7,7 +7,7 @@ import pytest
 from j5.backends import Backend, Environment
 from j5.boards import Board
 
-if TYPE_CHECKING:  # pragma: nocover
+if TYPE_CHECKING:
     from j5.components import Component  # noqa
 
 

--- a/tests/backends/test_backend.py
+++ b/tests/backends/test_backend.py
@@ -83,19 +83,19 @@ class MockBackend(Backend):
         return None
 
 
-def test_backend_instantiation():
+def test_backend_instantiation() -> None:
     """Test that we can instantiate a backend."""
     MockBackend()
 
 
-def test_environment_supported_boards():
+def test_environment_supported_boards() -> None:
     """Test that we can get the supported boards for a environment."""
     environment = MockEnvironment
     assert type(environment.supported_boards) == list
     assert len(environment.supported_boards) == 1
 
 
-def test_environment_board_backend_mapping():
+def test_environment_board_backend_mapping() -> None:
     """Test that the board_backend_mapping works."""
     environment = MockEnvironment
     assert type(environment.board_backend_mapping) == dict
@@ -103,13 +103,13 @@ def test_environment_board_backend_mapping():
     assert environment.board_backend_mapping[MockBoard] == MockBackend
 
 
-def test_environment_board_get_backend():
+def test_environment_board_get_backend() -> None:
     """Test that we can get the backend of a board."""
     environment = MockEnvironment
     assert issubclass(environment.get_backend(MockBoard), MockBackend)
 
 
-def test_environment_board_get_backend_unknown():
+def test_environment_board_get_backend_unknown() -> None:
     """Test that we can't get the backend of an unknown board."""
     environment = MockEnvironment
     with pytest.raises(NotImplementedError):

--- a/tests/backends/test_backend.py
+++ b/tests/backends/test_backend.py
@@ -28,7 +28,7 @@ class MockBoard(Board):
     @property
     def firmware_version(self) -> Optional[str]:
         """Get the firmware version of this board."""
-        return self._backend.get_firmware_version()
+        return None
 
     @staticmethod
     def supported_components() -> List[Type["Component"]]:
@@ -56,7 +56,7 @@ class Mock2Board(Board):
     @property
     def firmware_version(self) -> Optional[str]:
         """Get the firmware version of this board."""
-        return self._backend.get_firmware_version()
+        return None
 
     @staticmethod
     def supported_components() -> List[Type["Component"]]:

--- a/tests/backends/test_backend.py
+++ b/tests/backends/test_backend.py
@@ -21,7 +21,7 @@ class MockBoard(Board):
         """The serial number of the board."""
         return "TEST"
 
-    def make_safe(self):
+    def make_safe(self) -> None:
         """Make this board safe."""
         pass
 
@@ -31,7 +31,7 @@ class MockBoard(Board):
         return self._backend.get_firmware_version()
 
     @staticmethod
-    def supported_components():
+    def supported_components() -> List[Type["Component"]]:
         """List the types of component supported by this Board."""
         return []
 
@@ -49,7 +49,7 @@ class Mock2Board(Board):
         """The serial number of the board."""
         return "TEST2"
 
-    def make_safe(self):
+    def make_safe(self) -> None:
         """Make this board safe."""
         pass
 
@@ -59,7 +59,7 @@ class Mock2Board(Board):
         return self._backend.get_firmware_version()
 
     @staticmethod
-    def supported_components():
+    def supported_components() -> List[Type["Component"]]:
         """List the types of component supported by this Board."""
         return []
 

--- a/tests/backends/test_backend.py
+++ b/tests/backends/test_backend.py
@@ -35,11 +35,6 @@ class MockBoard(Board):
         """List the types of component supported by this Board."""
         return []
 
-    @staticmethod
-    def discover(backend: Backend):
-        """Get all boards of this type."""
-        return []
-
 
 class Mock2Board(Board):
     """A test board."""
@@ -66,11 +61,6 @@ class Mock2Board(Board):
     @staticmethod
     def supported_components():
         """List the types of component supported by this Board."""
-        return []
-
-    @staticmethod
-    def discover(backend: Backend):
-        """Get all boards of this type."""
         return []
 
 

--- a/tests/boards/sr/v4/test_power_board.py
+++ b/tests/boards/sr/v4/test_power_board.py
@@ -35,7 +35,7 @@ class MockPowerBoardBackend(
     board = PowerBoard
 
     @classmethod
-    def discover(cls):
+    def discover(cls) -> List["Board"]:
         """Discover the PowerBoards on this backend."""
         return []
 

--- a/tests/boards/sr/v4/test_power_board.py
+++ b/tests/boards/sr/v4/test_power_board.py
@@ -88,37 +88,37 @@ class MockPowerBoardBackend(
         pass
 
 
-def test_power_board_instantiation():
+def test_power_board_instantiation() -> None:
     """Test that we can instantiate a PowerBoard."""
     PowerBoard("SERIAL0", MockPowerBoardBackend())
 
 
-def test_power_board_discover():
+def test_power_board_discover() -> None:
     """Test that we can discover PowerBoards."""
     assert MockPowerBoardBackend.discover() == []
 
 
-def test_power_board_name():
+def test_power_board_name() -> None:
     """Test the name attribute of the PowerBoard."""
     pb = PowerBoard("SERIAL0", MockPowerBoardBackend())
 
     assert pb.name == "Student Robotics v4 Power Board"
 
 
-def test_power_board_serial():
+def test_power_board_serial() -> None:
     """Test the serial attribute of the PowerBoard."""
     pb = PowerBoard("SERIAL0", MockPowerBoardBackend())
 
     assert pb.serial == "SERIAL0"
 
 
-def test_power_board_make_safe():
+def test_power_board_make_safe() -> None:
     """Test the make_safe method of the PowerBoard."""
     pb = PowerBoard("SERIAL0", MockPowerBoardBackend())
     pb.make_safe()
 
 
-def test_power_board_outputs():
+def test_power_board_outputs() -> None:
     """Test the power outputs on the PowerBoard."""
     pb = PowerBoard("SERIAL0", MockPowerBoardBackend())
 
@@ -131,35 +131,35 @@ def test_power_board_outputs():
         assert type(output) is PowerOutput
 
 
-def test_power_board_piezo():
+def test_power_board_piezo() -> None:
     """Test the Piezo on the PowerBoard."""
     pb = PowerBoard("SERIAL0", MockPowerBoardBackend())
 
     assert type(pb.piezo) is Piezo
 
 
-def test_power_board_button():
+def test_power_board_button() -> None:
     """Test the Button on the PowerBoard."""
     pb = PowerBoard("SERIAL0", MockPowerBoardBackend())
 
     assert type(pb.start_button) is Button
 
 
-def test_power_board_battery_sensor():
+def test_power_board_battery_sensor() -> None:
     """Test the Battery Sensor on the Power Board."""
     pb = PowerBoard("SERIAL0", MockPowerBoardBackend())
 
     assert type(pb.battery_sensor) is BatterySensor
 
 
-def test_power_board_run_led():
+def test_power_board_run_led() -> None:
     """Test the run LED on the Power Board."""
     pb = PowerBoard("SERIAL0", MockPowerBoardBackend())
 
     assert type(pb._run_led) is LED
 
 
-def test_power_board_error_led():
+def test_power_board_error_led() -> None:
     """Test the error LED on the Power Board."""
     pb = PowerBoard("SERIAL0", MockPowerBoardBackend())
 

--- a/tests/boards/sr/v4/test_power_board.py
+++ b/tests/boards/sr/v4/test_power_board.py
@@ -67,7 +67,7 @@ class MockPowerBoardBackend(
         """Get the state of a button."""
         return True
 
-    def wait_until_button_pressed(self, identifier: int) -> bool:
+    def wait_until_button_pressed(self, identifier: int) -> None:
         """Wait until the button is pressed."""
         pass
 

--- a/tests/boards/sr/v4/test_power_board.py
+++ b/tests/boards/sr/v4/test_power_board.py
@@ -18,7 +18,7 @@ from j5.components import (
 )
 from j5.components.piezo import Pitch
 
-if TYPE_CHECKING:  # pragma: nocover
+if TYPE_CHECKING:
     from j5.boards import Board  # noqa
 
 

--- a/tests/boards/sr/v4/test_power_board.py
+++ b/tests/boards/sr/v4/test_power_board.py
@@ -1,6 +1,6 @@
 """Tests for the SR v4 Power Board and related classes."""
 from datetime import timedelta
-from typing import Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from j5.backends import Backend, Environment
 from j5.boards.sr.v4 import PowerBoard, PowerOutputGroup, PowerOutputPosition
@@ -17,6 +17,10 @@ from j5.components import (
     PowerOutputInterface,
 )
 from j5.components.piezo import Pitch
+
+if TYPE_CHECKING:  # pragma: nocover
+    from j5.boards import Board  # noqa
+
 
 MockEnvironment = Environment("MockEnvironment")
 

--- a/tests/boards/test_board.py
+++ b/tests/boards/test_board.py
@@ -6,7 +6,7 @@ import pytest
 from j5.backends import Backend, Environment
 from j5.boards.board import Board, BoardGroup
 
-if TYPE_CHECKING:  # pragma: nocover
+if TYPE_CHECKING:
     from j5.components import Component  # noqa
 
 

--- a/tests/boards/test_board.py
+++ b/tests/boards/test_board.py
@@ -26,7 +26,7 @@ class MockBoard(Board):
     @property
     def firmware_version(self) -> Optional[str]:
         """Get the firmware version of this board."""
-        return self._backend.get_firmware_version()
+        return None
 
     def make_safe(self) -> None:
         """Make this board safe."""

--- a/tests/boards/test_board.py
+++ b/tests/boards/test_board.py
@@ -1,10 +1,13 @@
 """Test the base classes for boards."""
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional, Type
 
 import pytest
 
 from j5.backends import Backend, Environment
 from j5.boards.board import Board, BoardGroup
+
+if TYPE_CHECKING:  # pragma: nocover
+    from j5.components import Component  # noqa
 
 
 class MockBoard(Board):

--- a/tests/boards/test_board.py
+++ b/tests/boards/test_board.py
@@ -234,13 +234,13 @@ def test_board_group_board_by_unknown() -> None:
     board_group = BoardGroup(MockBoard, OneBoardMockBackend)
 
     with pytest.raises(TypeError):
-        board_group[0]
+        board_group[0]  # type: ignore
 
     with pytest.raises(KeyError):
         board_group[""]
 
     with pytest.raises(TypeError):
-        board_group[{}]
+        board_group[{}]  # type: ignore
 
     with pytest.raises(KeyError):
         board_group["ARGHHHJ"]

--- a/tests/boards/test_board.py
+++ b/tests/boards/test_board.py
@@ -98,12 +98,12 @@ class TwoBoardsMockBackend(Backend):
         return [MockBoard("TESTSERIAL2"), MockBoard("TESTSERIAL1")]
 
 
-def test_testing_board_instantiation():
+def test_testing_board_instantiation() -> None:
     """Test that we can instantiate the testing board."""
     MockBoard("TESTSERIAL1")
 
 
-def test_testing_board_instantiation_with_constructor():
+def test_testing_board_instantiation_with_constructor() -> None:
     """Test that we can instantiate a board that has a constructor."""
     board = MockBoardWithConstructor("test", another_param="test2")
     assert board.test_param == "test"
@@ -111,7 +111,7 @@ def test_testing_board_instantiation_with_constructor():
     assert board.one_that_defaults is True
 
 
-def test_testing_board_name():
+def test_testing_board_name() -> None:
     """Test the name property of the board class."""
     tb = MockBoard("TESTSERIAL1")
 
@@ -119,7 +119,7 @@ def test_testing_board_name():
     assert type(tb.name) == str
 
 
-def test_testing_board_serial():
+def test_testing_board_serial() -> None:
     """Test the serial property of the board class."""
     tb = MockBoard("TESTSERIAL1")
 
@@ -127,52 +127,52 @@ def test_testing_board_serial():
     assert type(tb.serial) == str
 
 
-def test_testing_board_str():
+def test_testing_board_str() -> None:
     """Test the __str__ method of the board class."""
     tb = MockBoard("TESTSERIAL1")
 
     assert str(tb) == f"Testing Board - TESTSERIAL1"
 
 
-def test_testing_board_repr():
+def test_testing_board_repr() -> None:
     """Test the __repr__ method of the board class."""
     tb = MockBoard("TESTSERIAL1")
     assert repr(tb) == f"<MockBoard serial=TESTSERIAL1>"
 
 
-def test_discover():
+def test_discover() -> None:
     """Test that the detect all static method works."""
     assert NoBoardMockBackend.discover() == []
     assert len(OneBoardMockBackend.discover()) == 1
     assert len(TwoBoardsMockBackend.discover()) == 2
 
 
-def test_testing_board_added_to_boards_list():
+def test_testing_board_added_to_boards_list() -> None:
     """Test that an instantiated board is added to the boards list."""
     board = MockBoard("TESTSERIAL1")
     assert board in Board.BOARDS
 
 
-def test_create_boardgroup():
+def test_create_boardgroup() -> None:
     """Test that we can create a board group of testing boards."""
     board_group = BoardGroup(MockBoard, NoBoardMockBackend)
     assert type(board_group) == BoardGroup
 
 
-def test_board_group_update():
+def test_board_group_update() -> None:
     """Test that we can create a board group of testing boards."""
     board_group = BoardGroup(MockBoard, NoBoardMockBackend)
     board_group.update_boards()
 
 
-def test_board_group_singular():
+def test_board_group_singular() -> None:
     """Test that the singular function works on a board group."""
     board_group = BoardGroup(MockBoard, OneBoardMockBackend)
 
     assert type(board_group.singular()) == MockBoard
 
 
-def test_board_group_str():
+def test_board_group_str() -> None:
     """Test that the board group can be represented as a string."""
     assert str(BoardGroup(MockBoard, NoBoardMockBackend)) == "Group of Boards - []"
     assert str(BoardGroup(MockBoard, OneBoardMockBackend)) == \
@@ -181,7 +181,7 @@ def test_board_group_str():
         "Group of Boards - [Testing Board - TESTSERIAL1, Testing Board - TESTSERIAL2]"
 
 
-def test_board_group_singular_but_multiple_boards():
+def test_board_group_singular_but_multiple_boards() -> None:
     """Test that the singular function gets upset if there are multiple boards."""
     board_group = BoardGroup(MockBoard, TwoBoardsMockBackend)
 
@@ -189,7 +189,7 @@ def test_board_group_singular_but_multiple_boards():
         board_group.singular()
 
 
-def test_board_group_boards():
+def test_board_group_boards() -> None:
     """Test that the boards property works on a board group."""
     board_group = BoardGroup(MockBoard, OneBoardMockBackend)
 
@@ -198,7 +198,7 @@ def test_board_group_boards():
                 .values())[0]) == MockBoard
 
 
-def test_board_group_boards_multiple():
+def test_board_group_boards_multiple() -> None:
     """Test that the boards property works on multiple boards."""
     board_group = BoardGroup(MockBoard, TwoBoardsMockBackend)
 
@@ -207,7 +207,7 @@ def test_board_group_boards_multiple():
                 .values())[0]) == MockBoard
 
 
-def test_board_group_boards_zero():
+def test_board_group_boards_zero() -> None:
     """Test that the boards property works with no boards."""
     board_group = BoardGroup(MockBoard, NoBoardMockBackend)
 
@@ -217,7 +217,7 @@ def test_board_group_boards_zero():
         board_group._boards["SERIAL0"]
 
 
-def test_board_group_board_by_serial():
+def test_board_group_board_by_serial() -> None:
     """Test that the boards property works with serial indices."""
     board_group = BoardGroup(MockBoard, OneBoardMockBackend)
     BoardGroup(MockBoard, OneBoardMockBackend)
@@ -225,7 +225,7 @@ def test_board_group_board_by_serial():
     assert type(board_group[list(board_group._boards.values())[0].serial]) == MockBoard
 
 
-def test_board_group_board_by_unknown():
+def test_board_group_board_by_unknown() -> None:
     """Test that the boards property throws an exception with unknown indices."""
     board_group = BoardGroup(MockBoard, OneBoardMockBackend)
 
@@ -242,42 +242,42 @@ def test_board_group_board_by_unknown():
         board_group["ARGHHHJ"]
 
 
-def test_board_group_length_zero():
+def test_board_group_length_zero() -> None:
     """Test that the length operator works with no boards."""
     board_group = BoardGroup(MockBoard, NoBoardMockBackend)
 
     assert len(board_group) == 0
 
 
-def test_board_group_length():
+def test_board_group_length() -> None:
     """Test that the length operator works on a board group."""
     board_group = BoardGroup(MockBoard, OneBoardMockBackend)
 
     assert len(board_group) == 1
 
 
-def test_board_group_length_multiple():
+def test_board_group_length_multiple() -> None:
     """Test that the length operator works on multiple boards."""
     board_group = BoardGroup(MockBoard, TwoBoardsMockBackend)
 
     assert len(board_group) == 2
 
 
-def test_board_group_get_board_class():
+def test_board_group_get_board_class() -> None:
     """Test that the Board class getter works."""
     board_group = BoardGroup(MockBoard, TwoBoardsMockBackend)
 
     assert board_group.board_class is MockBoard
 
 
-def test_board_group_get_backend_class():
+def test_board_group_get_backend_class() -> None:
     """Test that the Backend class getter works."""
     board_group = BoardGroup(MockBoard, TwoBoardsMockBackend)
 
     assert board_group.backend_class is TwoBoardsMockBackend
 
 
-def test_board_group_get_boards():
+def test_board_group_get_boards() -> None:
     """Test that the boards list getter works."""
     board_group = BoardGroup(MockBoard, TwoBoardsMockBackend)
 
@@ -286,7 +286,7 @@ def test_board_group_get_boards():
     assert type(board_group.boards[0]) is MockBoard
 
 
-def test_board_group_iteration():
+def test_board_group_iteration() -> None:
     """Test that we can iterate over a BoardGroup."""
     board_group = BoardGroup(MockBoard, TwoBoardsMockBackend)
 
@@ -299,7 +299,7 @@ def test_board_group_iteration():
     assert count == 2
 
 
-def test_board_group_iteration_sorted_by_serial():
+def test_board_group_iteration_sorted_by_serial() -> None:
     """Test that the boards yielded by iterating over a BoardGroup are sorted."""
     board_group = BoardGroup(MockBoard, TwoBoardsMockBackend())
     serials = [board.serial for board in board_group]
@@ -307,7 +307,7 @@ def test_board_group_iteration_sorted_by_serial():
     assert serials[0] < serials[1]
 
 
-def test_board_group_simultaneous_iteration():
+def test_board_group_simultaneous_iteration() -> None:
     """Test that iterators returned by iter(BoardGroup) are independent."""
     board_group = BoardGroup(MockBoard, TwoBoardsMockBackend())
     iter1 = iter(board_group)

--- a/tests/boards/test_board.py
+++ b/tests/boards/test_board.py
@@ -302,7 +302,7 @@ def test_board_group_iteration() -> None:
 
 def test_board_group_iteration_sorted_by_serial() -> None:
     """Test that the boards yielded by iterating over a BoardGroup are sorted."""
-    board_group = BoardGroup(MockBoard, TwoBoardsMockBackend())
+    board_group = BoardGroup(MockBoard, TwoBoardsMockBackend)
     serials = [board.serial for board in board_group]
     assert len(serials) == 2
     assert serials[0] < serials[1]
@@ -310,7 +310,7 @@ def test_board_group_iteration_sorted_by_serial() -> None:
 
 def test_board_group_simultaneous_iteration() -> None:
     """Test that iterators returned by iter(BoardGroup) are independent."""
-    board_group = BoardGroup(MockBoard, TwoBoardsMockBackend())
+    board_group = BoardGroup(MockBoard, TwoBoardsMockBackend)
     iter1 = iter(board_group)
     iter2 = iter(board_group)
     assert next(iter1) is board_group["TESTSERIAL1"]

--- a/tests/boards/test_board.py
+++ b/tests/boards/test_board.py
@@ -28,12 +28,12 @@ class MockBoard(Board):
         """Get the firmware version of this board."""
         return self._backend.get_firmware_version()
 
-    def make_safe(self):
+    def make_safe(self) -> None:
         """Make this board safe."""
         pass
 
     @staticmethod
-    def supported_components():
+    def supported_components() -> List[Type["Component"]]:
         """List the types of component supported by this Board."""
         return []
 
@@ -41,7 +41,8 @@ class MockBoard(Board):
 class MockBoardWithConstructor(MockBoard):
     """A testing board with a constructor."""
 
-    def __init__(self, test_param, another_param, one_that_defaults=True):
+    def __init__(self, test_param: str, another_param: str,
+                 one_that_defaults: bool = True) -> None:
         self.test_param = test_param
         self.another_param = another_param
         self.one_that_defaults = one_that_defaults

--- a/tests/components/test_battery_sensor.py
+++ b/tests/components/test_battery_sensor.py
@@ -1,7 +1,6 @@
 """Tests for the Battery Sensor Classes."""
 from typing import List, Optional, Type
 
-from j5.backends import Backend
 from j5.boards import Board
 from j5.components import Component
 from j5.components.battery_sensor import BatterySensor, BatterySensorInterface
@@ -45,11 +44,6 @@ class MockBatterySensorBoard(Board):
     def make_safe(self) -> None:
         """Make this board safe."""
         pass
-
-    @staticmethod
-    def discover(backend: Backend) -> List['MockBatterySensorBoard']:
-        """Detect all of the boards on a given backend."""
-        return []
 
 
 def test_battery_sensor_interface_implementation():

--- a/tests/components/test_battery_sensor.py
+++ b/tests/components/test_battery_sensor.py
@@ -31,8 +31,8 @@ class MockBatterySensorBoard(Board):
         """The serial number of this board."""
         return "SERIAL"
 
-    @property
-    def supported_components(self) -> List[Type[Component]]:
+    @staticmethod
+    def supported_components() -> List[Type['Component']]:
         """List the types of component that this Board supports."""
         return [BatterySensor]
 

--- a/tests/components/test_battery_sensor.py
+++ b/tests/components/test_battery_sensor.py
@@ -1,9 +1,11 @@
 """Tests for the Battery Sensor Classes."""
-from typing import List, Optional, Type
+from typing import TYPE_CHECKING, List, Optional, Type
 
 from j5.boards import Board
-from j5.components import Component
 from j5.components.battery_sensor import BatterySensor, BatterySensorInterface
+
+if TYPE_CHECKING:  # pragma: nocover
+    from j5.components import Component  # noqa
 
 
 class MockBatterySensorDriver(BatterySensorInterface):

--- a/tests/components/test_battery_sensor.py
+++ b/tests/components/test_battery_sensor.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, List, Optional, Type
 from j5.boards import Board
 from j5.components.battery_sensor import BatterySensor, BatterySensorInterface
 
-if TYPE_CHECKING:  # pragma: nocover
+if TYPE_CHECKING:
     from j5.components import Component  # noqa
 
 

--- a/tests/components/test_battery_sensor.py
+++ b/tests/components/test_battery_sensor.py
@@ -46,29 +46,29 @@ class MockBatterySensorBoard(Board):
         pass
 
 
-def test_battery_sensor_interface_implementation():
+def test_battery_sensor_interface_implementation() -> None:
     """Test that we can implement the BatterySensorInterface."""
     MockBatterySensorDriver()
 
 
-def test_battery_sensor_instantiation():
+def test_battery_sensor_instantiation() -> None:
     """Test that we can instantiate a BatterySensor."""
     BatterySensor(0, MockBatterySensorBoard(), MockBatterySensorDriver())
 
 
-def test_battery_sensor_interface_class():
+def test_battery_sensor_interface_class() -> None:
     """Test that the interface class is correct."""
     assert BatterySensor.interface_class() is BatterySensorInterface
 
 
-def test_battery_sensor_voltage():
+def test_battery_sensor_voltage() -> None:
     """Test that we can get the voltage of a battery sensor."""
     battery = BatterySensor(0, MockBatterySensorBoard(), MockBatterySensorDriver())
     assert type(battery.voltage) is float
     assert battery.voltage == 5.0
 
 
-def test_battery_sensor_current():
+def test_battery_sensor_current() -> None:
     """Test that we can get the current of a battery sensor."""
     battery = BatterySensor(0, MockBatterySensorBoard(), MockBatterySensorDriver())
     assert type(battery.current) is float

--- a/tests/components/test_battery_sensor.py
+++ b/tests/components/test_battery_sensor.py
@@ -21,6 +21,9 @@ class MockBatterySensorDriver(BatterySensorInterface):
 class MockBatterySensorBoard(Board):
     """A testing board for the BatterySensor."""
 
+    def __init__(self) -> None:
+        pass
+
     @property
     def name(self) -> str:
         """The name of this board."""

--- a/tests/components/test_battery_sensor.py
+++ b/tests/components/test_battery_sensor.py
@@ -39,7 +39,7 @@ class MockBatterySensorBoard(Board):
     @property
     def firmware_version(self) -> Optional[str]:
         """Get the firmware version of this board."""
-        return self._backend.get_firmware_version()
+        return None
 
     def make_safe(self) -> None:
         """Make this board safe."""

--- a/tests/components/test_button.py
+++ b/tests/components/test_button.py
@@ -54,17 +54,17 @@ class MockButtonBoard(Board):
         return [Button]
 
 
-def test_button_interface_implementation():
+def test_button_interface_implementation() -> None:
     """Test that we can implement the button interface."""
     MockButtonDriver()
 
 
-def test_button_instantiation():
+def test_button_instantiation() -> None:
     """Test that we can instantiate a button."""
     Button(0, MockButtonBoard(), MockButtonDriver())
 
 
-def test_button_state():
+def test_button_state() -> None:
     """Test that we can get the state of the button."""
     driver = MockButtonDriver()
     button = Button(0, MockButtonBoard(), driver)
@@ -74,7 +74,7 @@ def test_button_state():
     assert button.is_pressed is True
 
 
-def test_button_wait_until_pressed():
+def test_button_wait_until_pressed() -> None:
     """Test that the button takes at least 0.2 secs to be pressed."""
     button = Button(0, MockButtonBoard(), MockButtonDriver())
     start_time = time()
@@ -86,6 +86,6 @@ def test_button_wait_until_pressed():
     assert time_taken < 2
 
 
-def test_button_interface_class():
+def test_button_interface_class() -> None:
     """Test that the Button Interface class is a ButtonInterface."""
     assert Button.interface_class() is ButtonInterface

--- a/tests/components/test_button.py
+++ b/tests/components/test_button.py
@@ -21,7 +21,7 @@ class MockButtonDriver(ButtonInterface):
         """Get the state of the button."""
         return self.state
 
-    def wait_until_button_pressed(self, identifier: int) -> bool:
+    def wait_until_button_pressed(self, identifier: int) -> None:
         """Wait until the button was pressed."""
         sleep(0.2)  # The mock driver always presses the button after 0.2s
 

--- a/tests/components/test_button.py
+++ b/tests/components/test_button.py
@@ -13,7 +13,7 @@ class MockButtonDriver(ButtonInterface):
     def __init__(self) -> None:
         self.state = False
 
-    def set_button_state(self, new_state: bool):
+    def set_button_state(self, new_state: bool) -> None:
         """Set the button state for testing purposes."""
         self.state = new_state
 
@@ -44,7 +44,7 @@ class MockButtonBoard(Board):
         """Get the firmware version of this board."""
         return self._backend.get_firmware_version()
 
-    def make_safe(self):
+    def make_safe(self) -> None:
         """Make this board safe."""
         pass
 

--- a/tests/components/test_button.py
+++ b/tests/components/test_button.py
@@ -2,7 +2,6 @@
 from time import sleep, time
 from typing import List, Optional, Type
 
-from j5.backends import Backend
 from j5.boards import Board
 from j5.components import Component
 from j5.components.button import Button, ButtonInterface
@@ -53,11 +52,6 @@ class MockButtonBoard(Board):
     def supported_components() -> List[Type[Component]]:
         """List the types of component that this Board supports."""
         return [Button]
-
-    @staticmethod
-    def discover(backend: Backend) -> List[Board]:
-        """Detect all of the boards on a given backend."""
-        return []
 
 
 def test_button_interface_implementation():

--- a/tests/components/test_button.py
+++ b/tests/components/test_button.py
@@ -42,7 +42,7 @@ class MockButtonBoard(Board):
     @property
     def firmware_version(self) -> Optional[str]:
         """Get the firmware version of this board."""
-        return self._backend.get_firmware_version()
+        return None
 
     def make_safe(self) -> None:
         """Make this board safe."""

--- a/tests/components/test_button.py
+++ b/tests/components/test_button.py
@@ -10,7 +10,7 @@ from j5.components.button import Button, ButtonInterface
 class MockButtonDriver(ButtonInterface):
     """A testing driver for the button component."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.state = False
 
     def set_button_state(self, new_state: bool):

--- a/tests/components/test_button.py
+++ b/tests/components/test_button.py
@@ -29,6 +29,9 @@ class MockButtonDriver(ButtonInterface):
 class MockButtonBoard(Board):
     """A testing board for the button."""
 
+    def __init__(self) -> None:
+        pass
+
     @property
     def name(self) -> str:
         """The name of this board."""

--- a/tests/components/test_gpio_pin.py
+++ b/tests/components/test_gpio_pin.py
@@ -100,22 +100,22 @@ class MockGPIOPinBoard(Board):
         return [GPIOPin]
 
 
-def test_gpio_pin_interface_implementation():
+def test_gpio_pin_interface_implementation() -> None:
     """Test that we can implement the GPIO pin interface."""
     MockGPIOPinDriver()
 
 
-def test_gpio_pin_instantiation():
+def test_gpio_pin_instantiation() -> None:
     """Test that we can instantiate a GPIO pin."""
     GPIOPin(0, MockGPIOPinBoard(), MockGPIOPinDriver())
 
 
-def test_gpio_pin_interface_class():
+def test_gpio_pin_interface_class() -> None:
     """Test that the GPIO pin Interface class is a GPIOPinInterface."""
     assert GPIOPin.interface_class() is GPIOPinInterface
 
 
-def test_pin_mode_getter():
+def test_pin_mode_getter() -> None:
     """Test the mode getter."""
     driver = MockGPIOPinDriver()
 
@@ -132,7 +132,7 @@ def test_pin_mode_getter():
     assert pin.mode is GPIOPinMode.DIGITAL_OUTPUT
 
 
-def test_pin_mode_setter():
+def test_pin_mode_setter() -> None:
     """Test the setter for the pin mode."""
     driver = MockGPIOPinDriver()
 
@@ -152,7 +152,7 @@ def test_pin_mode_setter():
         pin.mode = GPIOPinMode.ANALOGUE_INPUT
 
 
-def test_initial_mode():
+def test_initial_mode() -> None:
     """Test that the initial mode of the pin is set correctly."""
     driver = MockGPIOPinDriver()
 
@@ -207,7 +207,7 @@ def test_initial_mode():
         )
 
 
-def test_supported_modes_length():
+def test_supported_modes_length() -> None:
     """Test that a pin cannot be created with zero supported modes."""
     driver = MockGPIOPinDriver()
 
@@ -220,7 +220,7 @@ def test_supported_modes_length():
         )
 
 
-def test_required_pin_modes():
+def test_required_pin_modes() -> None:
     """Test the runtime check for required pin modes."""
     driver = MockGPIOPinDriver()
     pin = GPIOPin(
@@ -249,7 +249,7 @@ def test_required_pin_modes():
     ])
 
 
-def test_digital_state_getter():
+def test_digital_state_getter() -> None:
     """Test that we can get the digital state correctly."""
     driver = MockGPIOPinDriver()
     pin = GPIOPin(
@@ -288,7 +288,7 @@ def test_digital_state_getter():
         _ = pin.digital_state
 
 
-def test_digital_state_setter():
+def test_digital_state_setter() -> None:
     """Test that we can set the digital state."""
     driver = MockGPIOPinDriver()
     pin = GPIOPin(
@@ -310,7 +310,7 @@ def test_digital_state_setter():
     assert not driver._written_digital_state[0]
 
 
-def test_analogue_value_getter():
+def test_analogue_value_getter() -> None:
     """Test that we can get a scaled analogue value."""
     driver = MockGPIOPinDriver()
     pin = GPIOPin(
@@ -332,7 +332,7 @@ def test_analogue_value_getter():
         _ = pin.analogue_value
 
 
-def test_analogue_value_setter():
+def test_analogue_value_setter() -> None:
     """Test that we can set a scaled analogue value."""
     driver = MockGPIOPinDriver()
     pin = GPIOPin(

--- a/tests/components/test_gpio_pin.py
+++ b/tests/components/test_gpio_pin.py
@@ -31,7 +31,7 @@ class MockGPIOPinDriver(GPIOPinInterface):
             False for _ in range(0, self.pin_count)
         ]
 
-    def set_gpio_pin_mode(self, identifier: int, pin_mode: GPIOPinMode):
+    def set_gpio_pin_mode(self, identifier: int, pin_mode: GPIOPinMode) -> None:
         """Set the hardware mode of a pin."""
         self._mode[identifier] = pin_mode
 
@@ -39,15 +39,15 @@ class MockGPIOPinDriver(GPIOPinInterface):
         """Get the hardware mode of a GPIO pin."""
         return self._mode[identifier]
 
-    def write_gpio_pin_digital_state(self, identifier: int, state: bool):
+    def write_gpio_pin_digital_state(self, identifier: int, state: bool) -> None:
         """Write to the digital state of a GPIO pin."""
         self._written_digital_state[identifier] = state
 
-    def get_gpio_pin_digital_state(self, identifier: int):
+    def get_gpio_pin_digital_state(self, identifier: int) -> bool:
         """Get the last written state of the GPIO pin."""
         return self._written_digital_state[identifier]
 
-    def read_gpio_pin_digital_state(self, identifier: int):
+    def read_gpio_pin_digital_state(self, identifier: int) -> bool:
         """Read the digital state of the GPIO pin."""
         return self._digital_state[identifier]
 
@@ -90,7 +90,7 @@ class MockGPIOPinBoard(Board):
         """Get the firmware version of this board."""
         return None
 
-    def make_safe(self):
+    def make_safe(self) -> None:
         """Make this board safe."""
         pass
 

--- a/tests/components/test_gpio_pin.py
+++ b/tests/components/test_gpio_pin.py
@@ -3,7 +3,6 @@ from typing import List, Optional, Type
 
 import pytest
 
-from j5.backends import Backend
 from j5.boards import Board
 from j5.components import Component, NotSupportedByHardwareError
 from j5.components.gpio_pin import (
@@ -99,11 +98,6 @@ class MockGPIOPinBoard(Board):
     def supported_components() -> List[Type[Component]]:
         """List the types of component that this Board supports."""
         return [GPIOPin]
-
-    @staticmethod
-    def discover(backend: Backend) -> List[Board]:
-        """Detect all of the boards on a given backend."""
-        return []
 
 
 def test_gpio_pin_interface_implementation():

--- a/tests/components/test_gpio_pin.py
+++ b/tests/components/test_gpio_pin.py
@@ -75,6 +75,9 @@ class MockGPIOPinDriver(GPIOPinInterface):
 class MockGPIOPinBoard(Board):
     """A testing board for the GPIO pin."""
 
+    def __init__(self) -> None:
+        pass
+
     @property
     def name(self) -> str:
         """The name of this board."""

--- a/tests/components/test_gpio_pin.py
+++ b/tests/components/test_gpio_pin.py
@@ -16,7 +16,7 @@ from j5.components.gpio_pin import (
 class MockGPIOPinDriver(GPIOPinInterface):
     """A testing driver for the GPIO pin component."""
 
-    def __init__(self):
+    def __init__(self) -> None:
 
         self.pin_count: int = 10
         self._mode: List[GPIOPinMode] = [

--- a/tests/components/test_led.py
+++ b/tests/components/test_led.py
@@ -1,7 +1,6 @@
 """Tests for the LED Classes."""
 from typing import List, Optional, Type
 
-from j5.backends import Backend
 from j5.boards import Board
 from j5.components.led import LED, LEDInterface
 
@@ -44,11 +43,6 @@ class MockLEDBoard(Board):
     def make_safe(self):
         """Make this board safe."""
         pass
-
-    @staticmethod
-    def discover(backend: Backend):
-        """Detect all of the boards on a given backend."""
-        return []
 
 
 def test_led_interface_implementation():

--- a/tests/components/test_led.py
+++ b/tests/components/test_led.py
@@ -35,8 +35,8 @@ class MockLEDBoard(Board):
         """Get the firmware version of this board."""
         return self._backend.get_firmware_version()
 
-    @property
-    def supported_components(self) -> List[Type['Component']]:
+    @staticmethod
+    def supported_components() -> List[Type['Component']]:
         """List the types of component that this Board supports."""
         return [LED]
 

--- a/tests/components/test_led.py
+++ b/tests/components/test_led.py
@@ -45,17 +45,17 @@ class MockLEDBoard(Board):
         pass
 
 
-def test_led_interface_implementation():
+def test_led_interface_implementation() -> None:
     """Test that we can implement the LEDInterface."""
     MockLEDDriver()
 
 
-def test_led_instantiation():
+def test_led_instantiation() -> None:
     """Test that we can instantiate an LED."""
     LED(0, MockLEDBoard(), MockLEDDriver())
 
 
-def test_led_state():
+def test_led_state() -> None:
     """Test the state property of an LED."""
     led = LED(0, MockLEDBoard(), MockLEDDriver())
 

--- a/tests/components/test_led.py
+++ b/tests/components/test_led.py
@@ -1,8 +1,11 @@
 """Tests for the LED Classes."""
-from typing import List, Optional, Type
+from typing import TYPE_CHECKING, List, Optional, Type
 
 from j5.boards import Board
 from j5.components.led import LED, LEDInterface
+
+if TYPE_CHECKING:  # pragma: nocover
+    from j5.components import Component  # noqa
 
 
 class MockLEDDriver(LEDInterface):

--- a/tests/components/test_led.py
+++ b/tests/components/test_led.py
@@ -40,7 +40,7 @@ class MockLEDBoard(Board):
         """List the types of component that this Board supports."""
         return [LED]
 
-    def make_safe(self):
+    def make_safe(self) -> None:
         """Make this board safe."""
         pass
 

--- a/tests/components/test_led.py
+++ b/tests/components/test_led.py
@@ -33,7 +33,7 @@ class MockLEDBoard(Board):
     @property
     def firmware_version(self) -> Optional[str]:
         """Get the firmware version of this board."""
-        return self._backend.get_firmware_version()
+        return None
 
     @staticmethod
     def supported_components() -> List[Type['Component']]:

--- a/tests/components/test_led.py
+++ b/tests/components/test_led.py
@@ -20,6 +20,9 @@ class MockLEDDriver(LEDInterface):
 class MockLEDBoard(Board):
     """A testing board for the led."""
 
+    def __init__(self) -> None:
+        pass
+
     @property
     def name(self) -> str:
         """The name of this board."""

--- a/tests/components/test_led.py
+++ b/tests/components/test_led.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, List, Optional, Type
 from j5.boards import Board
 from j5.components.led import LED, LEDInterface
 
-if TYPE_CHECKING:  # pragma: nocover
+if TYPE_CHECKING:
     from j5.components import Component  # noqa
 
 

--- a/tests/components/test_piezo.py
+++ b/tests/components/test_piezo.py
@@ -81,11 +81,11 @@ def test_piezo_buzz_invalid_value() -> None:
     with pytest.raises(ValueError):
         piezo.buzz(timedelta(seconds=1), -42)
     with pytest.raises(TypeError):
-        piezo.buzz(timedelta(seconds=1), "j5")
+        piezo.buzz(timedelta(seconds=1), "j5")  # type: ignore
     with pytest.raises(ValueError):
         piezo.buzz(timedelta(seconds=-2), Note.D7)
     with pytest.raises(TypeError):
-        piezo.buzz(1, Note.D7)
+        piezo.buzz(1, Note.D7)  # type: ignore
 
 
 def test_note_reversed() -> None:

--- a/tests/components/test_piezo.py
+++ b/tests/components/test_piezo.py
@@ -1,12 +1,15 @@
 """Tests for the Piezo Classes."""
 
 from datetime import timedelta
-from typing import List, Optional, Type
+from typing import TYPE_CHECKING, List, Optional, Type
 
 import pytest
 
 from j5.boards import Board
 from j5.components.piezo import Note, Piezo, PiezoInterface
+
+if TYPE_CHECKING:  # pragma: nocover
+    from j5.components import Component  # noqa
 
 
 class MockPiezoDriver(PiezoInterface):

--- a/tests/components/test_piezo.py
+++ b/tests/components/test_piezo.py
@@ -5,7 +5,6 @@ from typing import List, Optional, Type
 
 import pytest
 
-from j5.backends import Backend
 from j5.boards import Board
 from j5.components.piezo import Note, Piezo, PiezoInterface
 
@@ -45,11 +44,6 @@ class MockPiezoBoard(Board):
     def make_safe(self):
         """Make this board safe."""
         pass
-
-    @staticmethod
-    def discover(backend: Backend):
-        """Detect all of the boards on a given backend."""
-        return []
 
 
 def test_piezo_interface_implementation():

--- a/tests/components/test_piezo.py
+++ b/tests/components/test_piezo.py
@@ -21,6 +21,9 @@ class MockPiezoDriver(PiezoInterface):
 class MockPiezoBoard(Board):
     """A testing board for the piezo."""
 
+    def __init__(self) -> None:
+        pass
+
     @property
     def name(self) -> str:
         """The name of this board."""

--- a/tests/components/test_piezo.py
+++ b/tests/components/test_piezo.py
@@ -8,7 +8,7 @@ import pytest
 from j5.boards import Board
 from j5.components.piezo import Note, Piezo, PiezoInterface
 
-if TYPE_CHECKING:  # pragma: nocover
+if TYPE_CHECKING:
     from j5.components import Component  # noqa
 
 

--- a/tests/components/test_piezo.py
+++ b/tests/components/test_piezo.py
@@ -46,30 +46,30 @@ class MockPiezoBoard(Board):
         pass
 
 
-def test_piezo_interface_implementation():
+def test_piezo_interface_implementation() -> None:
     """Test that we can implement the PiezoInterface."""
     MockPiezoDriver()
 
 
-def test_piezo_instantiation():
+def test_piezo_instantiation() -> None:
     """Test that we can instantiate an piezo."""
     Piezo(0, MockPiezoBoard(), MockPiezoDriver())
 
 
-def test_piezo_interface_class_method():
+def test_piezo_interface_class_method() -> None:
     """Tests piezo's interface_class method."""
     piezo = Piezo(0, MockPiezoBoard(), MockPiezoDriver())
     assert piezo.interface_class() is PiezoInterface
 
 
-def test_piezo_buzz_method():
+def test_piezo_buzz_method() -> None:
     """Tests piezo's buzz method's input validation."""
     piezo = Piezo(0, MockPiezoBoard(), MockPiezoDriver())
     piezo.buzz(timedelta(seconds=1), 2093)
     piezo.buzz(timedelta(minutes=1), Note.D7)
 
 
-def test_piezo_buzz_invalid_value():
+def test_piezo_buzz_invalid_value() -> None:
     """Test piezo's buzz method's input validation."""
     piezo = Piezo(0, MockPiezoBoard(), MockPiezoDriver())
     with pytest.raises(ValueError):
@@ -82,6 +82,6 @@ def test_piezo_buzz_invalid_value():
         piezo.buzz(1, Note.D7)
 
 
-def test_note_reversed():
+def test_note_reversed() -> None:
     """Test Note reversed dunder method."""
     assert list(reversed(list(Note))) == list(reversed(Note))

--- a/tests/components/test_piezo.py
+++ b/tests/components/test_piezo.py
@@ -34,7 +34,7 @@ class MockPiezoBoard(Board):
     @property
     def firmware_version(self) -> Optional[str]:
         """Get the firmware version of this board."""
-        return self._backend.get_firmware_version()
+        return None
 
     @staticmethod
     def supported_components() -> List[Type['Component']]:

--- a/tests/components/test_piezo.py
+++ b/tests/components/test_piezo.py
@@ -36,8 +36,8 @@ class MockPiezoBoard(Board):
         """Get the firmware version of this board."""
         return self._backend.get_firmware_version()
 
-    @property
-    def supported_components(self) -> List[Type['Component']]:
+    @staticmethod
+    def supported_components() -> List[Type['Component']]:
         """List the components that this Board supports."""
         return [Piezo]
 

--- a/tests/components/test_piezo.py
+++ b/tests/components/test_piezo.py
@@ -41,7 +41,7 @@ class MockPiezoBoard(Board):
         """List the components that this Board supports."""
         return [Piezo]
 
-    def make_safe(self):
+    def make_safe(self) -> None:
         """Make this board safe."""
         pass
 

--- a/tests/components/test_power_output.py
+++ b/tests/components/test_power_output.py
@@ -1,8 +1,11 @@
 """Tests for the power output classes."""
-from typing import List, Optional, Type
+from typing import TYPE_CHECKING, List, Optional, Type
 
 from j5.boards import Board
 from j5.components.power_output import PowerOutput, PowerOutputInterface
+
+if TYPE_CHECKING:  # pragma: nocover
+    from j5.components import Component  # noqa
 
 
 class MockPowerOutputDriver(PowerOutputInterface):

--- a/tests/components/test_power_output.py
+++ b/tests/components/test_power_output.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, List, Optional, Type
 from j5.boards import Board
 from j5.components.power_output import PowerOutput, PowerOutputInterface
 
-if TYPE_CHECKING:  # pragma: nocover
+if TYPE_CHECKING:
     from j5.components import Component  # noqa
 
 

--- a/tests/components/test_power_output.py
+++ b/tests/components/test_power_output.py
@@ -29,6 +29,9 @@ class MockPowerOutputDriver(PowerOutputInterface):
 class MockPowerOutputBoard(Board):
     """A testing board for the power output."""
 
+    def __init__(self) -> None:
+        pass
+
     @property
     def name(self) -> str:
         """The name of this board."""

--- a/tests/components/test_power_output.py
+++ b/tests/components/test_power_output.py
@@ -42,7 +42,7 @@ class MockPowerOutputBoard(Board):
     @property
     def firmware_version(self) -> Optional[str]:
         """Get the firmware version of this board."""
-        return self._backend.get_firmware_version()
+        return None
 
     @staticmethod
     def supported_components() -> List[Type["Component"]]:

--- a/tests/components/test_power_output.py
+++ b/tests/components/test_power_output.py
@@ -49,7 +49,7 @@ class MockPowerOutputBoard(Board):
         """List the types of component that this Board supports."""
         return [PowerOutput]
 
-    def make_safe(self):
+    def make_safe(self) -> None:
         """Make this board safe."""
         pass
 

--- a/tests/components/test_power_output.py
+++ b/tests/components/test_power_output.py
@@ -8,7 +8,7 @@ from j5.components.power_output import PowerOutput, PowerOutputInterface
 class MockPowerOutputDriver(PowerOutputInterface):
     """A testing driver for power outputs."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._enabled = False
 
     def get_power_output_enabled(self, identifier: int) -> bool:

--- a/tests/components/test_power_output.py
+++ b/tests/components/test_power_output.py
@@ -44,8 +44,8 @@ class MockPowerOutputBoard(Board):
         """Get the firmware version of this board."""
         return self._backend.get_firmware_version()
 
-    @property
-    def supported_components(self) -> List[Type["Component"]]:
+    @staticmethod
+    def supported_components() -> List[Type["Component"]]:
         """List the types of component that this Board supports."""
         return [PowerOutput]
 

--- a/tests/components/test_power_output.py
+++ b/tests/components/test_power_output.py
@@ -54,22 +54,22 @@ class MockPowerOutputBoard(Board):
         pass
 
 
-def test_power_output_interface_implementation():
+def test_power_output_interface_implementation() -> None:
     """Test that we can implement the PowerOutputInterface."""
     MockPowerOutputDriver()
 
 
-def test_power_output_instantiation():
+def test_power_output_instantiation() -> None:
     """Test that we can instantiate a PowerOutput."""
     PowerOutput(0, MockPowerOutputBoard(), MockPowerOutputDriver())
 
 
-def test_power_output_interface():
+def test_power_output_interface() -> None:
     """Test that the class returns the correct interface."""
     assert PowerOutput.interface_class() is PowerOutputInterface
 
 
-def test_power_output_enabled():
+def test_power_output_enabled() -> None:
     """Test the is_enabled property of a PowerOutput."""
     power_output = PowerOutput(0, MockPowerOutputBoard(), MockPowerOutputDriver())
     assert power_output.is_enabled is False
@@ -77,7 +77,7 @@ def test_power_output_enabled():
     assert power_output.is_enabled is True
 
 
-def test_power_output_current():
+def test_power_output_current() -> None:
     """Test the current property of a PowerOutput."""
     power_output = PowerOutput(0, MockPowerOutputBoard(), MockPowerOutputDriver())
     assert type(power_output.current) is float

--- a/tests/components/test_power_output.py
+++ b/tests/components/test_power_output.py
@@ -1,7 +1,6 @@
 """Tests for the power output classes."""
 from typing import List, Optional, Type
 
-from j5.backends import Backend
 from j5.boards import Board
 from j5.components.power_output import PowerOutput, PowerOutputInterface
 
@@ -53,11 +52,6 @@ class MockPowerOutputBoard(Board):
     def make_safe(self):
         """Make this board safe."""
         pass
-
-    @staticmethod
-    def discover(backend: Backend):
-        """Detect all of the boards on a given backend."""
-        return []
 
 
 def test_power_output_interface_implementation():

--- a/tests/components/test_servo.py
+++ b/tests/components/test_servo.py
@@ -6,7 +6,7 @@ import pytest
 from j5.boards import Board
 from j5.components.servo import Servo, ServoInterface, ServoPosition
 
-if TYPE_CHECKING:  # pragma: nocover
+if TYPE_CHECKING:
     from j5.components import Component  # noqa
 
 

--- a/tests/components/test_servo.py
+++ b/tests/components/test_servo.py
@@ -51,41 +51,41 @@ class MockServoBoard(Board):
         pass
 
 
-def test_servo_interface_implementation():
+def test_servo_interface_implementation() -> None:
     """Test that we can implement the ServoInterface."""
     MockServoDriver()
 
 
-def test_servo_interface_class():
+def test_servo_interface_class() -> None:
     """Test that the interface class is ServoInterface."""
     assert Servo.interface_class() is ServoInterface
 
 
-def test_servo_instantiation():
+def test_servo_instantiation() -> None:
     """Test that we can instantiate a Servo."""
     Servo(0, MockServoBoard(), MockServoDriver())
 
 
-def test_servo_get_position():
+def test_servo_get_position() -> None:
     """Test that we can get the position of a servo."""
     servo = Servo(2, MockServoBoard(), MockServoDriver())
     assert type(servo.position) is float
     assert servo.position == 0.5
 
 
-def test_servo_set_position():
+def test_servo_set_position() -> None:
     """Test that we can set the position of a servo."""
     servo = Servo(2, MockServoBoard(), MockServoDriver())
     servo.position = 0.6
 
 
-def test_servo_set_position_none():
+def test_servo_set_position_none() -> None:
     """Test that we can set the position of a servo to None."""
     servo = Servo(2, MockServoBoard(), MockServoDriver())
     servo.position = None
 
 
-def test_servo_set_position_out_of_bounds():
+def test_servo_set_position_out_of_bounds() -> None:
     """Test that we cannot set < -1 or > 1."""
     servo = Servo(2, MockServoBoard(), MockServoDriver())
 

--- a/tests/components/test_servo.py
+++ b/tests/components/test_servo.py
@@ -26,6 +26,9 @@ class MockServoDriver(ServoInterface):
 class MockServoBoard(Board):
     """A testing board for servos."""
 
+    def __init__(self) -> None:
+        pass
+
     @property
     def name(self) -> str:
         """The name of this board."""

--- a/tests/components/test_servo.py
+++ b/tests/components/test_servo.py
@@ -1,10 +1,13 @@
 """Tests for the servo classes."""
-from typing import List, Optional, Type
+from typing import TYPE_CHECKING, List, Optional, Type
 
 import pytest
 
 from j5.boards import Board
 from j5.components.servo import Servo, ServoInterface, ServoPosition
+
+if TYPE_CHECKING:  # pragma: nocover
+    from j5.components import Component  # noqa
 
 
 class MockServoDriver(ServoInterface):

--- a/tests/components/test_servo.py
+++ b/tests/components/test_servo.py
@@ -39,7 +39,7 @@ class MockServoBoard(Board):
     @property
     def firmware_version(self) -> Optional[str]:
         """Get the firmware version of this board."""
-        return self._backend.get_firmware_version()
+        return None
 
     @staticmethod
     def supported_components() -> List[Type["Component"]]:

--- a/tests/components/test_servo.py
+++ b/tests/components/test_servo.py
@@ -3,7 +3,6 @@ from typing import List, Optional, Type
 
 import pytest
 
-from j5.backends import Backend
 from j5.boards import Board
 from j5.components.servo import Servo, ServoInterface, ServoPosition
 
@@ -50,11 +49,6 @@ class MockServoBoard(Board):
     def make_safe(self):
         """Make this board safe."""
         pass
-
-    @staticmethod
-    def discover(backend: Backend):
-        """Detect all of the boards on a given backend."""
-        return []
 
 
 def test_servo_interface_implementation():

--- a/tests/components/test_servo.py
+++ b/tests/components/test_servo.py
@@ -46,7 +46,7 @@ class MockServoBoard(Board):
         """List the types of component that this Board supports."""
         return [Servo]
 
-    def make_safe(self):
+    def make_safe(self) -> None:
         """Make this board safe."""
         pass
 

--- a/tests/components/test_servo.py
+++ b/tests/components/test_servo.py
@@ -41,8 +41,8 @@ class MockServoBoard(Board):
         """Get the firmware version of this board."""
         return self._backend.get_firmware_version()
 
-    @property
-    def supported_components(self) -> List[Type["Component"]]:
+    @staticmethod
+    def supported_components() -> List[Type["Component"]]:
         """List the types of component that this Board supports."""
         return [Servo]
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,6 +1,6 @@
 """Bare basic tests."""
 
 
-def test_if_we_can_make_a_robot():
+def test_if_we_can_make_a_robot() -> None:
     """Test if we can import the library."""
     import j5  # noqa: W391, F401

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -18,7 +18,7 @@ class Robot(BaseRobot):
         self._env = TestEnvironment
 
 
-def test_robot_lock():
+def test_robot_lock() -> None:
     """Test that we cannot have more than one Robot object."""
     r1 = Robot()
 

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -14,7 +14,7 @@ TestEnvironment = Environment("TestEnvironment")
 class Robot(BaseRobot):
     """A robot."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._env = TestEnvironment
 
 


### PR DESCRIPTION
A recurring problem I've noticed is our tests getting out of sync with subtle changes to our API, which reduces my confidence that the tests are checking what we're expecting them to be checking. Hopefully, holding the tests to the same standard of type-safety as our main codebase would help to improve the situation.

I've tried to group similar changes into commits, so I'd recommend reviewing this PR on a commit-by-commit basis.