### PR TITLE
Update shell.nix in light of nixpkgs 19.03 release

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -10,11 +10,6 @@ in
   pkgs ? import pkgsSrc { overlays = [python37ByDefault]; },
 }:
 
-# Note that as of 2019-03-11, poetry is not currently available in any nixpkgs release.
-# To work around, invoke with:
-# nix-shell --arg pkgsSrc 'fetchTarball https://github.com/NixOS/nixpkgs/archive/master.tar.gz'
-# It should appear in NixOS/nixpkgs 19.03.
-
 with pkgs;
 
 stdenv.mkDerivation {

--- a/shell.nix
+++ b/shell.nix
@@ -1,13 +1,6 @@
-# A nixpkgs overlay to set python3Packages to python37Packages (the default is python36Packages).
-let
-  python37ByDefault = self: super: {
-    python3Packages = self.python37Packages;
-  };
-in
-
 {
   pkgsSrc ? <nixpkgs>,
-  pkgs ? import pkgsSrc { overlays = [python37ByDefault]; },
+  pkgs ? import pkgsSrc {},
 }:
 
 with pkgs;


### PR DESCRIPTION
The workarounds for making the poetry package available and for forcing python 3.7 are no longer required.