### PR TITLE
Use sets instead of lists for unordered collections

### DIFF
--- a/j5/backends/backend.py
+++ b/j5/backends/backend.py
@@ -1,7 +1,7 @@
 """The base classes for backends."""
 
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Dict, List, Optional, Set, Type
+from typing import TYPE_CHECKING, Dict, Optional, Set, Type
 
 if TYPE_CHECKING:
     from j5.boards import Board  # noqa
@@ -110,9 +110,9 @@ class Environment:
         self.board_backend_mapping: Dict[Type['Board'], Type[Backend]] = {}
 
     @property
-    def supported_boards(self) -> List[Type['Board']]:
+    def supported_boards(self) -> Set[Type['Board']]:
         """The boards that are supported by this backend group."""
-        return list(self.board_backend_mapping.keys())
+        return set(self.board_backend_mapping.keys())
 
     def __str__(self) -> str:
         """Get a string representation of this group."""

--- a/j5/backends/backend.py
+++ b/j5/backends/backend.py
@@ -1,7 +1,7 @@
 """The base classes for backends."""
 
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Dict, List, Optional, Type
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Type
 
 if TYPE_CHECKING:
     from j5.boards import Board  # noqa
@@ -82,7 +82,7 @@ class Backend(metaclass=BackendMeta):
 
     @classmethod
     @abstractmethod
-    def discover(cls) -> List['Board']:
+    def discover(cls) -> Set['Board']:
         """Discover boards that this backend can control."""
         raise NotImplementedError  # pragma: no cover
 

--- a/j5/backends/console/sr/v4/power_board.py
+++ b/j5/backends/console/sr/v4/power_board.py
@@ -1,7 +1,7 @@
 """Console Backend for the SR V4 power board."""
 
 from datetime import timedelta
-from typing import Dict, List, Optional, Type
+from typing import Dict, Optional, Set, Type
 
 from j5.backends import Backend
 from j5.backends.console.env import Console, ConsoleEnvironment
@@ -30,7 +30,7 @@ class SRV4PowerBoardConsoleBackend(
     board = PowerBoard
 
     @classmethod
-    def discover(cls) -> List[Board]:
+    def discover(cls) -> Set[Board]:
         """Discover boards that this backend can control."""
         raise NotImplementedError("The Console Backend cannot discover boards.")
 

--- a/j5/backends/hardware/sr/v4/power_board.py
+++ b/j5/backends/hardware/sr/v4/power_board.py
@@ -7,10 +7,10 @@ from time import sleep
 from typing import (
     Callable,
     Dict,
-    List,
     Mapping,
     NamedTuple,
     Optional,
+    Set,
     TypeVar,
     Union,
     cast,
@@ -123,14 +123,14 @@ class SRV4PowerBoardHardwareBackend(
 
     @classmethod
     @handle_usb_error
-    def discover(cls, find: Callable = usb.core.find) -> List[Board]:
+    def discover(cls, find: Callable = usb.core.find) -> Set[Board]:
         """Discover boards that this backend can control."""
-        boards: List[Board] = []
+        boards: Set[Board] = set()
         device_list = find(idVendor=0x1bda, idProduct=0x0010, find_all=True)
         for device in device_list:
             backend = cls(device)
             board = PowerBoard(backend.serial, backend)
-            boards.append(cast(Board, board))
+            boards.add(cast(Board, board))
         return boards
 
     @handle_usb_error

--- a/j5/boards/board.py
+++ b/j5/boards/board.py
@@ -14,9 +14,9 @@ if TYPE_CHECKING:  # pragma: nocover
 class Board(metaclass=ABCMeta):
     """A collection of hardware that has an implementation."""
 
-    # BOARDS is a list of currently instantiated boards.
+    # BOARDS is a set of currently instantiated boards.
     # This is useful to know so that we can make them safe in a crash.
-    BOARDS: List['Board'] = []
+    BOARDS: Set['Board'] = set()
 
     def __str__(self) -> str:
         """A string representation of this board."""
@@ -25,7 +25,7 @@ class Board(metaclass=ABCMeta):
     def __new__(cls, *args, **kwargs):  # type: ignore
         """Ensure any instantiated board is added to the boards list."""
         instance = super().__new__(cls)
-        Board.BOARDS.append(instance)
+        Board.BOARDS.add(instance)
         return instance
 
     def __repr__(self) -> str:

--- a/j5/boards/board.py
+++ b/j5/boards/board.py
@@ -83,8 +83,7 @@ class BoardGroup:
         """Update the boards in this group to see if new boards have been added."""
         self._boards: Dict[str, Board] = OrderedDict()
         discovered_boards = self._backend_class.discover()
-        discovered_boards.sort(key=lambda b: b.serial)
-        for board in discovered_boards:
+        for board in sorted(discovered_boards, key=lambda b: b.serial):
             self._boards.update({board.serial: board})
 
     def singular(self) -> Board:

--- a/j5/boards/board.py
+++ b/j5/boards/board.py
@@ -3,7 +3,7 @@
 import atexit
 from abc import ABCMeta, abstractmethod
 from collections import OrderedDict
-from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Type
+from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Set, Type
 
 from j5.backends import Backend
 
@@ -57,7 +57,7 @@ class Board(metaclass=ABCMeta):
 
     @staticmethod
     @abstractmethod
-    def supported_components() -> List[Type['Component']]:
+    def supported_components() -> Set[Type['Component']]:
         """The types of component supported by this board."""
         raise NotImplementedError  # pragma: no cover
 

--- a/j5/boards/sr/v4/power_board.py
+++ b/j5/boards/sr/v4/power_board.py
@@ -2,7 +2,7 @@
 
 from enum import Enum
 from time import sleep
-from typing import TYPE_CHECKING, List, Mapping, Optional, cast
+from typing import TYPE_CHECKING, Mapping, Optional, Set, cast
 
 from j5.backends import Backend
 from j5.boards import Board
@@ -119,6 +119,6 @@ class PowerBoard(Board):
             counter += 1
 
     @staticmethod
-    def supported_components() -> List["Type[Component]"]:
+    def supported_components() -> Set["Type[Component]"]:
         """List the types of components supported by this board."""
-        return [PowerOutput, Piezo, Button, BatterySensor, LED]
+        return {PowerOutput, Piezo, Button, BatterySensor, LED}

--- a/tests/backends/hardware/sr/v4/test_power_board.py
+++ b/tests/backends/hardware/sr/v4/test_power_board.py
@@ -277,7 +277,7 @@ def test_backend_discover() -> None:
     found_boards = SRV4PowerBoardHardwareBackend.discover(find=mock_find)
 
     assert len(found_boards) == 4
-    assert type(found_boards[0]) is PowerBoard
+    assert all(type(board) is PowerBoard for board in found_boards)
 
 
 def test_backend_cleanup() -> None:

--- a/tests/backends/test_backend.py
+++ b/tests/backends/test_backend.py
@@ -1,6 +1,6 @@
 """Tests for the base backend classes."""
 
-from typing import TYPE_CHECKING, List, Optional, Set, Type
+from typing import TYPE_CHECKING, Optional, Set, Type
 
 import pytest
 
@@ -77,9 +77,9 @@ class MockBackend(Backend):
     board = MockBoard
 
     @classmethod
-    def discover(cls) -> List[Board]:
+    def discover(cls) -> Set[Board]:
         """Discover boards available on this backend."""
-        return []
+        return set()
 
     def get_firmware_version(self) -> Optional[str]:
         """Get the firmware version of the board."""

--- a/tests/backends/test_backend.py
+++ b/tests/backends/test_backend.py
@@ -94,7 +94,7 @@ def test_backend_instantiation() -> None:
 def test_environment_supported_boards() -> None:
     """Test that we can get the supported boards for a environment."""
     environment = MockEnvironment
-    assert type(environment.supported_boards) == list
+    assert type(environment.supported_boards) is set
     assert len(environment.supported_boards) == 1
 
 

--- a/tests/backends/test_backend.py
+++ b/tests/backends/test_backend.py
@@ -1,6 +1,6 @@
 """Tests for the base backend classes."""
 
-from typing import TYPE_CHECKING, List, Optional, Type
+from typing import TYPE_CHECKING, List, Optional, Set, Type
 
 import pytest
 
@@ -34,9 +34,9 @@ class MockBoard(Board):
         return None
 
     @staticmethod
-    def supported_components() -> List[Type["Component"]]:
+    def supported_components() -> Set[Type["Component"]]:
         """List the types of component supported by this Board."""
-        return []
+        return set()
 
 
 class Mock2Board(Board):
@@ -62,9 +62,9 @@ class Mock2Board(Board):
         return None
 
     @staticmethod
-    def supported_components() -> List[Type["Component"]]:
+    def supported_components() -> Set[Type["Component"]]:
         """List the types of component supported by this Board."""
-        return []
+        return set()
 
 
 MockEnvironment = Environment("TestBackendGroup")

--- a/tests/boards/sr/v4/test_power_board.py
+++ b/tests/boards/sr/v4/test_power_board.py
@@ -1,6 +1,6 @@
 """Tests for the SR v4 Power Board and related classes."""
 from datetime import timedelta
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Optional, Set
 
 from j5.backends import Backend, Environment
 from j5.boards.sr.v4 import PowerBoard, PowerOutputGroup, PowerOutputPosition
@@ -39,9 +39,9 @@ class MockPowerBoardBackend(
     board = PowerBoard
 
     @classmethod
-    def discover(cls) -> List["Board"]:
+    def discover(cls) -> Set["Board"]:
         """Discover the PowerBoards on this backend."""
-        return []
+        return set()
 
     def get_firmware_version(self) -> Optional[str]:
         """Get the firmware version reported by the board."""
@@ -99,7 +99,7 @@ def test_power_board_instantiation() -> None:
 
 def test_power_board_discover() -> None:
     """Test that we can discover PowerBoards."""
-    assert MockPowerBoardBackend.discover() == []
+    assert MockPowerBoardBackend.discover() == set()
 
 
 def test_power_board_name() -> None:

--- a/tests/boards/test_board.py
+++ b/tests/boards/test_board.py
@@ -1,5 +1,5 @@
 """Test the base classes for boards."""
-from typing import TYPE_CHECKING, List, Optional, Set, Type
+from typing import TYPE_CHECKING, Optional, Set, Type
 
 import pytest
 
@@ -62,9 +62,9 @@ class NoBoardMockBackend(Backend):
         return None
 
     @classmethod
-    def discover(cls) -> List[Board]:
+    def discover(cls) -> Set[Board]:
         """Discover boards available on this backend."""
-        return []
+        return set()
 
 
 class OneBoardMockBackend(Backend):
@@ -78,9 +78,9 @@ class OneBoardMockBackend(Backend):
         return None
 
     @classmethod
-    def discover(cls) -> List[Board]:
+    def discover(cls) -> Set[Board]:
         """Discover boards available on this backend."""
-        return [MockBoard("TESTSERIAL1")]
+        return {MockBoard("TESTSERIAL1")}
 
 
 class TwoBoardsMockBackend(Backend):
@@ -94,12 +94,9 @@ class TwoBoardsMockBackend(Backend):
         return None
 
     @classmethod
-    def discover(cls) -> List[Board]:
+    def discover(cls) -> Set[Board]:
         """Discover boards available on this backend."""
-        # These serial numbers are deliberately in reverse lexiographic order, to ensure
-        # that sorting the boards (as tested by
-        # test_board_group_iteration_sorted_by_serial) actually has an effect.
-        return [MockBoard("TESTSERIAL2"), MockBoard("TESTSERIAL1")]
+        return {MockBoard("TESTSERIAL1"), MockBoard("TESTSERIAL2")}
 
 
 def test_testing_board_instantiation() -> None:
@@ -146,7 +143,7 @@ def test_testing_board_repr() -> None:
 
 def test_discover() -> None:
     """Test that the detect all static method works."""
-    assert NoBoardMockBackend.discover() == []
+    assert NoBoardMockBackend.discover() == set()
     assert len(OneBoardMockBackend.discover()) == 1
     assert len(TwoBoardsMockBackend.discover()) == 2
 

--- a/tests/boards/test_board.py
+++ b/tests/boards/test_board.py
@@ -1,5 +1,5 @@
 """Test the base classes for boards."""
-from typing import TYPE_CHECKING, List, Optional, Type
+from typing import TYPE_CHECKING, List, Optional, Set, Type
 
 import pytest
 
@@ -36,9 +36,9 @@ class MockBoard(Board):
         pass
 
     @staticmethod
-    def supported_components() -> List[Type["Component"]]:
+    def supported_components() -> Set[Type["Component"]]:
         """List the types of component supported by this Board."""
-        return []
+        return set()
 
 
 class MockBoardWithConstructor(MockBoard):

--- a/tests/components/test_battery_sensor.py
+++ b/tests/components/test_battery_sensor.py
@@ -1,5 +1,5 @@
 """Tests for the Battery Sensor Classes."""
-from typing import TYPE_CHECKING, List, Optional, Type
+from typing import TYPE_CHECKING, Optional, Set, Type
 
 from j5.boards import Board
 from j5.components.battery_sensor import BatterySensor, BatterySensorInterface
@@ -37,9 +37,9 @@ class MockBatterySensorBoard(Board):
         return "SERIAL"
 
     @staticmethod
-    def supported_components() -> List[Type['Component']]:
+    def supported_components() -> Set[Type['Component']]:
         """List the types of component that this Board supports."""
-        return [BatterySensor]
+        return {BatterySensor}
 
     @property
     def firmware_version(self) -> Optional[str]:

--- a/tests/components/test_button.py
+++ b/tests/components/test_button.py
@@ -1,6 +1,6 @@
 """Tests for the Button Classes."""
 from time import sleep, time
-from typing import List, Optional, Type
+from typing import Optional, Set, Type
 
 from j5.boards import Board
 from j5.components import Component
@@ -52,9 +52,9 @@ class MockButtonBoard(Board):
         pass
 
     @staticmethod
-    def supported_components() -> List[Type[Component]]:
+    def supported_components() -> Set[Type[Component]]:
         """List the types of component that this Board supports."""
-        return [Button]
+        return {Button}
 
 
 def test_button_interface_implementation() -> None:

--- a/tests/components/test_gpio_pin.py
+++ b/tests/components/test_gpio_pin.py
@@ -1,5 +1,5 @@
 """Tests for the GPIO Pin Classes."""
-from typing import List, Optional, Type
+from typing import List, Optional, Set, Type
 
 import pytest
 
@@ -98,9 +98,9 @@ class MockGPIOPinBoard(Board):
         pass
 
     @staticmethod
-    def supported_components() -> List[Type[Component]]:
+    def supported_components() -> Set[Type[Component]]:
         """List the types of component that this Board supports."""
-        return [GPIOPin]
+        return {GPIOPin}
 
 
 def test_gpio_pin_interface_implementation() -> None:

--- a/tests/components/test_led.py
+++ b/tests/components/test_led.py
@@ -1,5 +1,5 @@
 """Tests for the LED Classes."""
-from typing import TYPE_CHECKING, List, Optional, Type
+from typing import TYPE_CHECKING, Optional, Set, Type
 
 from j5.boards import Board
 from j5.components.led import LED, LEDInterface
@@ -42,9 +42,9 @@ class MockLEDBoard(Board):
         return None
 
     @staticmethod
-    def supported_components() -> List[Type['Component']]:
+    def supported_components() -> Set[Type['Component']]:
         """List the types of component that this Board supports."""
-        return [LED]
+        return {LED}
 
     def make_safe(self) -> None:
         """Make this board safe."""

--- a/tests/components/test_motor.py
+++ b/tests/components/test_motor.py
@@ -1,5 +1,5 @@
 """Tests for the motor classes."""
-from typing import TYPE_CHECKING, List, Mapping, Optional, Type
+from typing import TYPE_CHECKING, Mapping, Optional, Set, Type
 
 import pytest
 
@@ -59,9 +59,9 @@ class MockMotorBoard(Board):
         return None
 
     @staticmethod
-    def supported_components() -> List[Type["Component"]]:
+    def supported_components() -> Set[Type["Component"]]:
         """List the types of component that this Board supports."""
-        return [Motor]
+        return {Motor}
 
     def make_safe(self) -> None:
         """Make this board safe."""

--- a/tests/components/test_piezo.py
+++ b/tests/components/test_piezo.py
@@ -1,7 +1,7 @@
 """Tests for the Piezo Classes."""
 
 from datetime import timedelta
-from typing import TYPE_CHECKING, List, Optional, Type
+from typing import TYPE_CHECKING, Optional, Set, Type
 
 import pytest
 
@@ -43,9 +43,9 @@ class MockPiezoBoard(Board):
         return None
 
     @staticmethod
-    def supported_components() -> List[Type['Component']]:
+    def supported_components() -> Set[Type['Component']]:
         """List the components that this Board supports."""
-        return [Piezo]
+        return {Piezo}
 
     def make_safe(self) -> None:
         """Make this board safe."""

--- a/tests/components/test_power_output.py
+++ b/tests/components/test_power_output.py
@@ -1,5 +1,5 @@
 """Tests for the power output classes."""
-from typing import TYPE_CHECKING, List, Optional, Type
+from typing import TYPE_CHECKING, Optional, Set, Type
 
 from j5.boards import Board
 from j5.components.power_output import PowerOutput, PowerOutputInterface
@@ -51,9 +51,9 @@ class MockPowerOutputBoard(Board):
         return None
 
     @staticmethod
-    def supported_components() -> List[Type["Component"]]:
+    def supported_components() -> Set[Type["Component"]]:
         """List the types of component that this Board supports."""
-        return [PowerOutput]
+        return {PowerOutput}
 
     def make_safe(self) -> None:
         """Make this board safe."""

--- a/tests/components/test_servo.py
+++ b/tests/components/test_servo.py
@@ -1,5 +1,5 @@
 """Tests for the servo classes."""
-from typing import TYPE_CHECKING, List, Optional, Type
+from typing import TYPE_CHECKING, Optional, Set, Type
 
 import pytest
 
@@ -48,9 +48,9 @@ class MockServoBoard(Board):
         return None
 
     @staticmethod
-    def supported_components() -> List[Type["Component"]]:
+    def supported_components() -> Set[Type["Component"]]:
         """List the types of component that this Board supports."""
-        return [Servo]
+        return {Servo}
 
     def make_safe(self) -> None:
         """Make this board safe."""


### PR DESCRIPTION
Our code uses lists in a lot of places where a set would be more appropriate, due to the collection not having a useful order to it. This PR changes the following methods/properties to be sets instead of lists: `Board.supported_components`, `Backend.discover`, `Environment.supported_boards` and `Board.BOARDS`. Resolves #207.

I'd recommend reviewing this PR commit-by-commit.

Note: I'd also like to change `supported_modes` in the `GPIOPin` component, but I don't know what to do about the fact that `initial_mode` defaults to the first item of `supported_modes`, implying that `supported_modes` is actually ordered. Possible solutions may be to require `initial_mode` to be explicitly given, or to determine its default value some other way, or to leave this bit of code as it is. Thoughts?