### PR TITLE
Use just firmware_version for Backend

### DIFF
--- a/j5/backends/backend.py
+++ b/j5/backends/backend.py
@@ -95,9 +95,10 @@ class Backend(metaclass=BackendMeta):
         """Environment the backend belongs too."""
         raise NotImplementedError  # pragma: no cover
 
+    @property
     @abstractmethod
-    def get_firmware_version(self) -> Optional[str]:
-        """Get the firmware version of the board."""
+    def firmware_version(self) -> Optional[str]:
+        """The firmware version of the board."""
         raise NotImplementedError  # pragma: no cover
 
 

--- a/j5/backends/console/sr/v4/motor_board.py
+++ b/j5/backends/console/sr/v4/motor_board.py
@@ -35,10 +35,6 @@ class SRV4MotorBoardConsoleBackend(
         # Setup console helper
         self._console = console_class(f"{self.board.__name__}({self._serial})")
 
-    def get_firmware_version(self) -> Optional[str]:
-        """The firmware version reported by the board."""
-        return None  # Console, so no firmware
-
     @property
     def serial(self) -> str:
         """The serial number reported by the board."""
@@ -47,7 +43,7 @@ class SRV4MotorBoardConsoleBackend(
     @property
     def firmware_version(self) -> Optional[str]:
         """The firmware version reported by the board."""
-        return self.get_firmware_version()
+        return None  # Console, so no firmware
 
     def get_motor_state(self, identifier: int) -> MotorState:
         """Get the current motor state."""

--- a/j5/backends/console/sr/v4/power_board.py
+++ b/j5/backends/console/sr/v4/power_board.py
@@ -58,10 +58,6 @@ class SRV4PowerBoardConsoleBackend(
         """The serial number reported by the board."""
         return self._serial
 
-    def get_firmware_version(self) -> Optional[str]:
-        """Get the firmware version reported by the board."""
-        return None
-
     def get_power_output_enabled(self, identifier: int) -> bool:
         """Get whether a power output is enabled."""
         try:

--- a/j5/backends/hardware/sr/v4/motor_board.py
+++ b/j5/backends/hardware/sr/v4/motor_board.py
@@ -94,7 +94,7 @@ class SRV4MotorBoardHardwareBackend(
         )
 
         # Check we have the correct firmware version.
-        version = self.get_firmware_version()
+        version = self.firmware_version
         if version != "3":
             raise CommunicationError(
                 f"Unexpected firmware version: {version}, expected: \"3\".",
@@ -139,8 +139,9 @@ class SRV4MotorBoardHardwareBackend(
         ldata = bdata.decode('utf-8')
         return ldata.rstrip()
 
-    def get_firmware_version(self) -> Optional[str]:
-        """Get the firmware version of the board."""
+    @property
+    def firmware_version(self) -> Optional[str]:
+        """The firmware version of the board."""
         self.send_command(CMD_VERSION)
         firmware_data = self.read_serial_line()
         model = firmware_data[:5]

--- a/j5/backends/hardware/sr/v4/power_board.py
+++ b/j5/backends/hardware/sr/v4/power_board.py
@@ -9,7 +9,6 @@ from typing import (
     Dict,
     Mapping,
     NamedTuple,
-    Optional,
     Set,
     TypeVar,
     Union,
@@ -198,10 +197,6 @@ class SRV4PowerBoardHardwareBackend(
         """The serial number reported by the board."""
         # https://github.com/python/mypy/issues/1362
         return self._usb_device.serial_number  # type: ignore
-
-    def get_firmware_version(self) -> Optional[str]:
-        """Get the firmware version reported by the board."""
-        return str(self.firmware_version)
 
     def get_power_output_enabled(self, identifier: int) -> bool:
         """Get whether a power output is enabled."""

--- a/j5/boards/sr/v4/motor_board.py
+++ b/j5/boards/sr/v4/motor_board.py
@@ -36,7 +36,7 @@ class MotorBoard(Board):
     @property
     def firmware_version(self) -> Optional[str]:
         """Get the firmware version of the board."""
-        return self._backend.get_firmware_version()
+        return self._backend.firmware_version
 
     @property
     def motors(self) -> List[Motor]:

--- a/j5/boards/sr/v4/power_board.py
+++ b/j5/boards/sr/v4/power_board.py
@@ -81,7 +81,7 @@ class PowerBoard(Board):
     @property
     def firmware_version(self) -> Optional[str]:
         """Get the firmware version of the board."""
-        return self._backend.get_firmware_version()
+        return self._backend.firmware_version
 
     @property
     def outputs(self) -> PowerOutputGroup:

--- a/tests/backends/console/sr/v4/test_motor_board.py
+++ b/tests/backends/console/sr/v4/test_motor_board.py
@@ -33,8 +33,6 @@ def test_backend_firmware_version() -> None:
 
     assert backend.firmware_version is None
 
-    assert backend.get_firmware_version() is None
-
 
 def test_backend_serial_number() -> None:
     """Test that we can get the serial number."""

--- a/tests/backends/console/sr/v4/test_power_board.py
+++ b/tests/backends/console/sr/v4/test_power_board.py
@@ -37,8 +37,6 @@ def test_backend_firmware_version() -> None:
 
     assert backend.firmware_version is None
 
-    assert backend.get_firmware_version() is None
-
 
 def test_backend_serial_number() -> None:
     """Test that we can get the serial number."""

--- a/tests/backends/hardware/sr/v4/test_motor_board.py
+++ b/tests/backends/hardware/sr/v4/test_motor_board.py
@@ -263,13 +263,13 @@ def test_get_firmware_version() -> None:
     backend = SRV4MotorBoardHardwareBackend("COM0", serial_class=MotorSerial)
     backend._serial.flush()
     backend._serial.expects_prepend(b'\x01')
-    assert backend.get_firmware_version() == "3"
+    assert backend.firmware_version == "3"
 
     backend._serial.flush()
     backend._serial.expects_prepend(b'\x01')
     backend._serial.buffer_append(b'PBV4C:5', newline=True)
     with pytest.raises(CommunicationError):
-        backend.get_firmware_version()
+        backend.firmware_version
 
 
 def test_get_set_motor_state() -> None:

--- a/tests/backends/test_backend.py
+++ b/tests/backends/test_backend.py
@@ -82,8 +82,9 @@ class MockBackend(Backend):
         """Discover boards available on this backend."""
         return set()
 
-    def get_firmware_version(self) -> Optional[str]:
-        """Get the firmware version of the board."""
+    @property
+    def firmware_version(self) -> Optional[str]:
+        """The firmware version of the board."""
         return None
 
 

--- a/tests/boards/sr/v4/test_motor_board.py
+++ b/tests/boards/sr/v4/test_motor_board.py
@@ -31,8 +31,9 @@ class MockMotorBoardBackend(MotorInterface, Backend):
             for _ in range(0, 2)
         ]
 
-    def get_firmware_version(self) -> Optional[str]:
-        """Get the firmware version reported by the board."""
+    @property
+    def firmware_version(self) -> Optional[str]:
+        """The firmware version of the board."""
         return None
 
     def get_motor_state(self, identifier: int) -> MotorState:

--- a/tests/boards/sr/v4/test_power_board.py
+++ b/tests/boards/sr/v4/test_power_board.py
@@ -43,8 +43,9 @@ class MockPowerBoardBackend(
         """Discover the PowerBoards on this backend."""
         return set()
 
-    def get_firmware_version(self) -> Optional[str]:
-        """Get the firmware version reported by the board."""
+    @property
+    def firmware_version(self) -> Optional[str]:
+        """The firmware version of the board."""
         return None
 
     def get_power_output_enabled(self, identifier: int) -> bool:

--- a/tests/boards/test_board.py
+++ b/tests/boards/test_board.py
@@ -58,8 +58,9 @@ class NoBoardMockBackend(Backend):
     environment = Environment("MockEnvironment")
     board = MockBoard
 
-    def get_firmware_version(self) -> Optional[str]:
-        """Get the firmware version of the board."""
+    @property
+    def firmware_version(self) -> Optional[str]:
+        """The firmware version of the board."""
         return None
 
     @classmethod
@@ -74,8 +75,9 @@ class OneBoardMockBackend(Backend):
     environment = Environment("MockEnvironment")
     board = MockBoard
 
-    def get_firmware_version(self) -> Optional[str]:
-        """Get the firmware version of the board."""
+    @property
+    def firmware_version(self) -> Optional[str]:
+        """The firmware version of the board."""
         return None
 
     @classmethod
@@ -90,8 +92,9 @@ class TwoBoardsMockBackend(Backend):
     environment = Environment("MockEnvironment")
     board = MockBoard
 
-    def get_firmware_version(self) -> Optional[str]:
-        """Get the firmware version of the board."""
+    @property
+    def firmware_version(self) -> Optional[str]:
+        """The firmware version of the board."""
         return None
 
     @classmethod


### PR DESCRIPTION
This is instead of `get_firmware_version` and `firmware_version`, which also had duplication in some places.
Fixes #236 