### PR TITLE
Merge master into feature branch before running CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,13 @@ jobs:
       - image: j5api/ci:3.6
     steps:
       - checkout
+      - run:
+          name: Merge with master
+          command: |
+            git config user.name "dummy"
+            git config user.email "dummy@example.org"
+            git fetch origin master
+            git merge --squash origin/master
       - restore_cache:
           keys:
             - pip-packages-{{ .Branch }}-{{ checksum "poetry.lock" }}


### PR DESCRIPTION
This prevents the situation where a PR is able to be merged but
will cause CI to fail when merged with master.

See #256 for an example of this in action.