### PR TITLE
[WIP] Metadata provider

### DIFF
--- a/j5/backends/hardware/metadata_provider.py
+++ b/j5/backends/hardware/metadata_provider.py
@@ -1,0 +1,36 @@
+import glob
+
+class MetadataProviderFilesystemBackend(MetadataProviderInterface, Backend):
+  environment = HardwareEnvironment
+  board = MetadataProvider
+
+  @classmethod
+  def discover(cls, glob_pattern: str, iglob: Callable = glob.iglob) -> Set[Board]:
+    return set(cls._discover_board(path) for path in iglob(glob_pattern))
+
+  @classmethod
+  def _discover_board(cls, path: str) -> Board:
+    backend = cls(pathlib.Path(path))
+    board = MetadataProvider(path, backend)
+    return cast(Board, board)
+
+  def __init__(self, path: pathlib.Path):
+    self._path = path
+
+  @property
+  def firmware_version(self) -> None:
+    return None
+
+  def get_metadata(self) -> Metadata:
+    with open(self.path, "r") as file:
+      obj = json.load(file)
+    return self._validate_metadata(obj)
+
+  def _validate_metadata(self, obj: Any) -> Metadata:
+    if isinstance(obj, dict):
+      for key, value in obj.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+          raise TypeError
+    else:
+      raise TypeError
+    return obj

--- a/j5/boards/metadata_provider.py
+++ b/j5/boards/metadata_provider.py
@@ -1,0 +1,34 @@
+Metadata = Dict[str, str]
+
+class MetadataProviderInterface(Interface):
+  @abstractmethod
+  def get_metadata(self) -> Metadata:
+    raise NotImplementedError
+
+class MetadataProvider(Board):
+  def __init__(self, serial: str, backend: MetadataProviderInterface):
+    self._serial = serial
+    self._backend = backend
+
+  @property
+  def name(self) -> str:
+    return "Metadata provider"
+
+  @property
+  def serial(self) -> str:
+    return self._serial
+
+  @property
+  def firmware_version(self) -> None:
+    return None
+
+  def make_safe(self) -> None:
+    pass
+
+  @staticmethod
+  def supported_component() -> Set[Type['Component']]:
+    return set()
+
+  @property
+  def metadata(self) -> Metadata:
+    return self._backend.get_metadata()

--- a/tests/backends/hardware/test_metadata_provider.py
+++ b/tests/backends/hardware/test_metadata_provider.py
@@ -1,0 +1,18 @@
+def mock_iglob(pattern):
+  assert pattern == "/test/*.json"
+  return iter([
+    "/test/1.json",
+    "/test/2.json",
+  ])
+
+def test_discover() -> None:
+  found_boards = MetadataProviderFilesystemBackend.discover("/test/*.json", iglob=mock_iglob)
+  assert len(found_boards) == 2
+  assert all(type(board) is MetadataProvider for board in found_boards)
+
+def test_discover_serials():
+  found_boards = MetadataProviderFilesystemBackend.discover("/test/*.json", iglob=mock_iglob)
+  serials = {board.serial for board in found_boards}
+  assert serials == {"/test/1.json", "/test/2.json"}
+
+

--- a/tests/boards/test_metadata_provider.py
+++ b/tests/boards/test_metadata_provider.py
@@ -1,0 +1,33 @@
+class MockMetadataProviderBackend(MetadataProviderInterface, Backend):
+  def get_metadata(self) -> Metadata:
+    return {
+      "environment": "comp",
+      "corner": "1",
+    }
+
+def test_instantiation() -> None:
+  MetadataProvider("SERIAL0", MockMetadataProviderBackend())
+
+def test_name() -> None:
+  mp = MetadataProvider("SERIAL0", MockMetadataProviderBackend())
+  assert mp.name == "Metadata provider"
+
+def test_serial() -> None:
+  mp = MetadataProvider("SERIAL0", MockMetadataProviderBackend())
+  assert mp.serial == "SERIAL0"
+
+def test_firmware_version() -> None:
+  mp = MetadataProvider("SERIAL0", MockMetadataProviderBackend())
+  assert mp.firmware_version is None
+
+def test_make_safe() -> None:
+  mp = MetadataProvider("SERIAL0", MockMetadataProviderBackend())
+  mp.make_safe()
+
+def test_metadata() -> None:
+  mp = MetadataProvider("SERIAL0", MockMetadataProviderBackend())
+  assert type(mp.metadata) is dict
+  assert mp.metadata == {
+    "environment": "comp",
+    "corner": "1",
+  }


### PR DESCRIPTION
WORK IN PROGRESS

The metadata provider "board" models a way for the user program to obtain metadata about the context the program is being run in. Metadata is currently restricted to be a dictionary of string keys to string values. A choice of backends will allow this metadata to be obtained from various sources.

The main use case for this is for obtaining the robot star t zone and the dev-or-comp status from a file on a competition USB key. The specifics of this (file location, file format, and how this is information is presented in the competitor-facing API) are the responsibility of the API provider.