### PR TITLE
update_boards: re-use existing _boards dictionary

### DIFF
--- a/j5/boards/board.py
+++ b/j5/boards/board.py
@@ -94,7 +94,7 @@ class BoardGroup(Generic[T]):
 
     def update_boards(self) -> None:
         """Update the boards in this group to see if new boards have been added."""
-        self._boards: Dict[str, T] = OrderedDict()
+        self._boards.clear()
         discovered_boards = self._backend_class.discover()
         for board in sorted(discovered_boards, key=lambda b: b.serial):
             self._boards.update({board.serial: cast(T, board)})

--- a/tests/boards/test_board.py
+++ b/tests/boards/test_board.py
@@ -165,9 +165,25 @@ def test_create_boardgroup() -> None:
 
 
 def test_board_group_update() -> None:
-    """Test that we can create a board group of testing boards."""
-    board_group = BoardGroup[MockBoard](NoBoardMockBackend)
+    """Test that we can refresh the list of boards."""
+    board_group = BoardGroup[MockBoard](OneBoardMockBackend)
+    assert len(board_group._boards) == 1
+    old_board = list(board_group._boards.values())[0]
+
     board_group.update_boards()
+    assert len(board_group._boards) == 1
+    new_board = list(board_group._boards.values())[0]
+    assert new_board is not old_board
+
+
+def test_board_group_update_removes_old_boards() -> None:
+    """Test that boards that are no longer discovered are removed from the board group."""
+    board_group = BoardGroup[MockBoard](OneBoardMockBackend)
+    assert len(board_group._boards) == 1
+
+    board_group._backend_class = NoBoardMockBackend
+    board_group.update_boards()
+    assert len(board_group._boards) == 0
 
 
 def test_board_group_singular() -> None:


### PR DESCRIPTION
This fixes one of the problems in #318:

```
j5/boards/board.py:97: error: Attribute '_boards' already defined on line 91
```

It also adds some tests to ensure this still behaves as expected.