### PR TITLE
Fix RawUSBHardwareBackend.serial

### DIFF
--- a/j5/backends/hardware/j5/raw_usb/raw_usb.py
+++ b/j5/backends/hardware/j5/raw_usb/raw_usb.py
@@ -95,7 +95,7 @@ class RawUSBHardwareBackend(metaclass=BackendMeta):
     def serial(self) -> str:
         """The serial number reported by the board."""
         # https://github.com/python/mypy/issues/1362
-        return self._usb_device.serial_number  # type: ignore
+        return self._usb_device.serial_number()
 
     @handle_usb_error
     def __del__(self) -> None:

--- a/tests/backends/hardware/sr/v4/test_power_board.py
+++ b/tests/backends/hardware/sr/v4/test_power_board.py
@@ -268,7 +268,7 @@ def test_backend_serial_number() -> None:
     device = MockUSBPowerBoardDevice("SERIAL0")
     backend = SRV4PowerBoardHardwareBackend(device)
 
-    assert backend.serial() == "SERIAL0"
+    assert backend.serial == "SERIAL0"
 
 
 def test_backend_get_power_output_enabled() -> None:

--- a/tests/backends/hardware/sr/v4/test_servo_board.py
+++ b/tests/backends/hardware/sr/v4/test_servo_board.py
@@ -177,7 +177,7 @@ def test_backend_serial_number() -> None:
     device = MockUSBServoBoardDevice("SERIAL0")
     backend = SRV4ServoBoardHardwareBackend(device)
 
-    assert backend.serial() == "SERIAL0"
+    assert backend.serial == "SERIAL0"
 
 
 def test_backend_get_servo_status() -> None:


### PR DESCRIPTION
It's a property, not a method; however the underlying `usb.core.Device.serial_number` is a method.

This fixes a couple of the issues in #318:

```
tests/backends/hardware/sr/v4/test_servo_board.py:180: error: "str" not callable
tests/backends/hardware/sr/v4/test_power_board.py:271: error: "str" not callable
```