### PR TITLE
Fix BaseRobot.__new__ calling __init__ twice

### DIFF
--- a/j5/base_robot.py
+++ b/j5/base_robot.py
@@ -17,12 +17,7 @@ class BaseRobot:
     def __new__(cls, *args, **kwargs) -> 'BaseRobot':  # type: ignore
         """Create a new instance of the class."""
         obj: BaseRobot = super().__new__(cls)
-
-        # We have to ignore some of the types here as they are unknown.
-        obj.__init__(*args, **kwargs)  # type: ignore
-
         obj._obtain_lock()
-
         return obj
 
     def make_safe(self) -> None:


### PR DESCRIPTION
The Python runtime automatically calls `__init__` after calling `__new__`, you don't have to do it explicitly inside `__new__` as well.

```python
from j5.base_robot import BaseRobot

class MyRobot(BaseRobot):
  def __init__(self, arg=None):
    print(f"__init__({arg})")

MyRobot(123) # prints "__init__(123)" twice unless this change is made
```