### PR TITLE
Add isort command to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,5 +17,8 @@ test:
 test-cov:
 	$(CMD) pytest --cov=$(PYMODULE) tests --cov-report html
 
+isort:
+	$(CMD) isort --recursive $(PYMODULE) tests tests_hw
+
 clean:
 	git clean -Xdf # Delete all files in .gitignore


### PR DESCRIPTION
This allows you to run 'make isort' to fix imports in all python
source files.