### PR TITLE
Change order of tasks in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 CMD:=poetry run
 PYMODULE:=j5
 
-all: lint type test
+all: type test lint
 
 lint:
 	$(CMD) flake8 $(PYMODULE) tests tests_hw


### PR DESCRIPTION
This changes the order in which linting, testing and typechecking
is done when the 'make' command is executed. Reasoning is that
one usually wants to see and fix functional or type errors before
dealing with linting errors.