### PR TITLE
Moves board name properties to class attributes

### DIFF
--- a/j5/boards/arduino/uno.py
+++ b/j5/boards/arduino/uno.py
@@ -34,6 +34,7 @@ class ArduinoUnoBoard(Board):
     _led: LED
     _digital_pins: Mapping[int, GPIOPin]
     _analogue_pins: Mapping[AnaloguePin, GPIOPin]
+    name: str = "Arduino Uno"
 
     def __init__(self, serial: str, backend: Backend):
         self._serial = serial
@@ -71,11 +72,6 @@ class ArduinoUnoBoard(Board):
             )
             for i in AnaloguePin
         }
-
-    @property
-    def name(self) -> str:
-        """Get a human friendly name for this board."""
-        return "Arduino Uno"
 
     @property
     def serial(self) -> str:

--- a/j5/boards/sr/v4/motor_board.py
+++ b/j5/boards/sr/v4/motor_board.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:  # pragma: no cover
 class MotorBoard(Board):
     """Student Robotics v4 Motor Board."""
 
+    name: str = "Student Robotics v4 Motor Board"
+
     def __init__(self, serial: str, backend: Backend):
         self._serial = serial
         self._backend = backend
@@ -22,11 +24,6 @@ class MotorBoard(Board):
             Motor(output, cast(MotorInterface, self._backend))
             for output in range(0, 2)
         ]
-
-    @property
-    def name(self) -> str:
-        """Get a human friendly name for this board."""
-        return "Student Robotics v4 Motor Board"
 
     @property
     def serial(self) -> str:

--- a/j5/boards/sr/v4/power_board.py
+++ b/j5/boards/sr/v4/power_board.py
@@ -45,6 +45,8 @@ class PowerOutputPosition(Enum):
 class PowerBoard(Board):
     """Student Robotics v4 Power Board."""
 
+    name: str = "Student Robotics v4 Power Board"
+
     def __init__(self, serial: str, backend: Backend):
         self._serial = serial
         self._backend = backend
@@ -67,11 +69,6 @@ class PowerBoard(Board):
 
         self._run_led = LED(0, cast("LEDInterface", self._backend))
         self._error_led = LED(1, cast("LEDInterface", self._backend))
-
-    @property
-    def name(self) -> str:
-        """Get a human friendly name for this board."""
-        return "Student Robotics v4 Power Board"
 
     @property
     def serial(self) -> str:

--- a/j5/boards/sr/v4/servo_board.py
+++ b/j5/boards/sr/v4/servo_board.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:  # pragma: no cover
 class ServoBoard(Board):
     """Student Robotics v4 Servo Board."""
 
+    name: str = "Student Robotics v4 Servo Board"
+
     def __init__(self, serial: str, backend: Backend):
         self._serial = serial
         self._backend = backend
@@ -22,11 +24,6 @@ class ServoBoard(Board):
             Servo(servo, cast(ServoInterface, self._backend))
             for servo in range(0, 12)
         ]
-
-    @property
-    def name(self) -> str:
-        """Get a human friendly name for this board."""
-        return "Student Robotics v4 Servo Board"
 
     @property
     def serial(self) -> str:


### PR DESCRIPTION
Board.name within the base class has been kept as a property to maintain the abstract aspect of the name attribute

Closes #335 