### PR TITLE
Set SO_REUSEADDR on the lock socket

### DIFF
--- a/j5/base_robot.py
+++ b/j5/base_robot.py
@@ -34,6 +34,7 @@ class BaseRobot:
         if not hasattr(self, '_lock'):
 
             self._lock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self._lock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
             try:
                 self._lock.bind(('localhost', lock_port))


### PR DESCRIPTION
This should prevent the OS from reserving the address for a short
period after the process dies, preventing new processes from
binding to the address.

However I've been unable to reproduce that issue myself, so I've got no idea if it solves the issue. I would not recommend merging until this is confirmed.