### PR TITLE
Fix arduino backend timeout

### DIFF
--- a/j5/backends/hardware/sb/arduino.py
+++ b/j5/backends/hardware/sb/arduino.py
@@ -89,6 +89,7 @@ class SBArduinoHardwareBackend(
             serial_port=serial_port,
             serial_class=serial_class,
             baud=115200,
+            timeout=timedelta(milliseconds=1250),
         )
 
         self._digital_pins: Mapping[int, DigitalPinData] = {

--- a/tests/backends/hardware/j5/mock_serial.py
+++ b/tests/backends/hardware/j5/mock_serial.py
@@ -26,7 +26,7 @@ class MockSerial:
         assert parity == 'N'
         assert stopbits == 1
         assert timeout is not None
-        assert 0.1 <= timeout <= 0.3  # Acceptable range of timeouts
+        assert 0.1 <= timeout <= 1.5  # Acceptable range of timeouts
 
     def close(self) -> None:
         """Close the serial port."""


### PR DESCRIPTION
When performing ultrasound operations, the arduino may wait up to
1 second before sending a response. We need to ensure the timeout
on a serial read is long enough to accomodate this.

Separately, I've opened https://github.com/sourcebots/arduino-fw/issues/28
to track possibly reducing the timeout in the firmware.