### PR TITLE
Use "raise from" in power board / servo board error messages

### DIFF
--- a/j5/backends/hardware/j5/raw_usb.py
+++ b/j5/backends/hardware/j5/raw_usb.py
@@ -69,7 +69,7 @@ def handle_usb_error(func: Callable[..., RT]) -> Callable[..., RT]:  # type: ign
         try:
             return func(*args, **kwargs)
         except usb.core.USBError as e:
-            raise USBCommunicationError(e)
+            raise USBCommunicationError(e) from e
     return catch_exceptions
 
 


### PR DESCRIPTION
Ultimately, the inner exception should go into the log and
only the outer exception should be raised.