### PR TITLE
Improve error message when the SR servo board isn't powered

### DIFF
--- a/j5/backends/hardware/j5/raw_usb.py
+++ b/j5/backends/hardware/j5/raw_usb.py
@@ -50,7 +50,10 @@ class USBCommunicationError(CommunicationError):
     """An error occurred during USB communication."""
 
     def __init__(self, usb_error: usb.core.USBError) -> None:
-        super().__init__(usb_error.strerror)
+        message = usb_error.strerror
+        if usb_error.errno == 110:  # "operation timed out"
+            message += "; are you sure the servo board is being correctly powered?"
+        super().__init__(message)
 
 
 RT = TypeVar('RT')

--- a/stubs/pytest.pyi
+++ b/stubs/pytest.pyi
@@ -4,12 +4,12 @@ Type stubs for pytest.
 Note that stubs are only written for the parts that we use.
 """
 
-from typing import ContextManager, Type
+from typing import ContextManager, Optional, Type
 
 
 # This function actually has more arguments than are specified here, and the
 # context manager actually yields a _pytest._code.ExceptionInfo instead of None.
 # We don't use either of these features, so I don't think its worth including
 # them in our type stub. We can always change it later.
-def raises(exc_type: Type[Exception]) -> ContextManager[None]:
+def raises(exc_type: Type[Exception], match: Optional[str] = None) -> ContextManager[None]:
     ...

--- a/stubs/usb/core.pyi
+++ b/stubs/usb/core.pyi
@@ -25,6 +25,7 @@ class Device:
     ) -> bytes: ...
 
 class USBError(Exception):
+    errno: int
     strerror: str
 
 def find(

--- a/stubs/usb/core.pyi
+++ b/stubs/usb/core.pyi
@@ -28,6 +28,13 @@ class USBError(Exception):
     errno: int
     strerror: str
 
+    def __init__(
+        self,
+        strerror: str,
+        error_code: Optional[int] = None,
+        errno: Optional[int] = None,
+    ): ...
+
 def find(
         find_all: bool = False,
         idVendor: Optional[int] = None,

--- a/tests/backends/hardware/j5/test_raw_usb.py
+++ b/tests/backends/hardware/j5/test_raw_usb.py
@@ -52,7 +52,7 @@ def test_usb_error_handler_decorator_for_servo_board_power() -> None:
     """Test that the handle_usb_error decorator works."""
     @handle_usb_error
     def test_func() -> None:
-        raise usb.core.USBError("Test", errno = 110)
+        raise usb.core.USBError("Test", errno=110)
 
     regex = r".*are you sure the servo board is being correctly powered.*"
     with pytest.raises(USBCommunicationError, match=regex):

--- a/tests/backends/hardware/j5/test_raw_usb.py
+++ b/tests/backends/hardware/j5/test_raw_usb.py
@@ -46,3 +46,14 @@ def test_usb_error_handler_decorator() -> None:
 
     with pytest.raises(USBCommunicationError):
         test_func()
+
+
+def test_usb_error_handler_decorator_for_servo_board_power() -> None:
+    """Test that the handle_usb_error decorator works."""
+    @handle_usb_error
+    def test_func() -> None:
+        raise usb.core.USBError("Test", errno = 110)
+
+    regex = r".*are you sure the servo board is being correctly powered.*"
+    with pytest.raises(USBCommunicationError, match=regex):
+        test_func()


### PR DESCRIPTION
In this situation, we get a timeout since the firmware gets stuck
waiting for a response to its request to turn on the SMPS.