### PR TITLE
Fix pbv4 broken Student Robotics link.

### DIFF
--- a/docs/hardware/srobo/pbv4.rst
+++ b/docs/hardware/srobo/pbv4.rst
@@ -160,6 +160,6 @@ use the board but it may be of interest to some people.
 .. _Hardware designs: https://github.com/srobo/power-v4-hw
 
 
-.. Note:: Some of the documentation in this section has been taken and modified from `Student Robotics`_. See here_ for more information.
+.. Note:: Some of the documentation in this section has been taken and modified from Student Robotics. See here_ for more information.
 
 .. _here: LICENSE.html


### PR DESCRIPTION
pbv4.rst attempts to link to `Student Robotics` but this link doesn't
actually go anywhere, resulting in broken formatting. mbv4 doesn't link
to Student Robotics and only links to the license. This commit removes
the link from pbv4 and makes it like mbv4, without a link to Student
Robotics.