### PR TITLE
Add makefile file for running http server for built docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -13,6 +13,9 @@ help:
 
 .PHONY: help Makefile
 
+serve-html: html
+	python -m http.server --directory "$(BUILDDIR)/html" 8000
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile


### PR DESCRIPTION
`make -C docs serve-http` now builds the HTML docs and serves them
up at http://0.0.0.0:8000/