### PR TITLE
Ensure j5.components.motor.power bounds check applies to integers

### DIFF
--- a/j5/components/motor.py
+++ b/j5/components/motor.py
@@ -60,7 +60,7 @@ class Motor(Component):
     @power.setter
     def power(self, new_power: MotorState) -> None:
         """Set the current state of this output."""
-        if isinstance(new_power, float):
+        if not isinstance(new_power, MotorSpecialState):
             if new_power < -1 or new_power > 1:
                 raise ValueError("Motor power must be between 1 and -1.")
         self._backend.set_motor_state(self._identifier, new_power)

--- a/tests/components/test_motor.py
+++ b/tests/components/test_motor.py
@@ -96,7 +96,10 @@ def test_motor_set_state_out_of_bounds() -> None:
     motor = Motor(0, MockMotorDriver())
 
     with pytest.raises(ValueError):
+        motor.power = 2
+    with pytest.raises(ValueError):
         motor.power = 1.1
-
+    with pytest.raises(ValueError):
+        motor.power = -3
     with pytest.raises(ValueError):
         motor.power = -1.2


### PR DESCRIPTION
Fixes #431.