### PR TITLE
Improve Servo Board Backend Tests

### DIFF
--- a/j5/backends/hardware/sr/v4/servo_board.py
+++ b/j5/backends/hardware/sr/v4/servo_board.py
@@ -62,8 +62,7 @@ class SRV4ServoBoardHardwareBackend(
         ]
 
         # Initialise servos.
-        with self._lock:
-            self._usb_device.ctrl_transfer(0, 64, 0, 12, b"")
+        self._write(CMD_WRITE_INIT, b"")
 
         for s in range(0, 12):
             self.set_servo_position(s, 0.0)

--- a/j5/backends/hardware/sr/v4/servo_board.py
+++ b/j5/backends/hardware/sr/v4/servo_board.py
@@ -94,17 +94,21 @@ class SRV4ServoBoardHardwareBackend(
 
         Currently reads back the last known position as we cannot read from the hardware.
         """
+        if identifier not in range(0, 12) or not isinstance(identifier, int):
+            raise ValueError("Only integers 0 - 12 are valid servo identifiers.")
         return self._positions[identifier]
 
     def set_servo_position(self, identifier: int, position: ServoPosition) -> None:
         """Set the position of a servo."""
-        if identifier not in range(0, 12):
+        if identifier not in range(0, 12) or not isinstance(identifier, int):
             raise ValueError("Only integers 0 - 12 are valid servo identifiers.")
 
         if position is None:
             raise NotSupportedByHardwareError(
                 f"{self.board.name} does not support unpowered servos.",
             )
+        elif position < -1 or position > 1:
+            raise ValueError("Only numbers between -1 and 1 are valid servo positions.")
 
         self._positions[identifier] = position
         value = round(position * 100)

--- a/tests/backends/hardware/sr/v4/test_servo_board.py
+++ b/tests/backends/hardware/sr/v4/test_servo_board.py
@@ -50,6 +50,7 @@ class MockUSBServoBoardDevice(usb.core.Device):
         self.serial = serial_number
         self.firmware_version = fw_version
         self._ctx = MockUSBContext()  # Used by PyUSB when cleaning up the device.
+        self.timers_initialised = False
 
     @property
     def serial_number(self) -> str:
@@ -110,7 +111,15 @@ class MockUSBServoBoardDevice(usb.core.Device):
             # Set Servo.
             return self.write_servo(wValue, data)
         if wIndex == 12:
-            # Initialise. Behaviour unknown currently
+            # Initialise the board.
+            # Turns on the timer interrupt to the I2C GPIO expander.
+            assert data == b''
+            assert wValue == 0
+
+            # We don't want to do this twice.
+            assert not self.timers_initialised
+
+            self.timers_initialised = True
             return
 
         raise NotImplementedError
@@ -119,6 +128,7 @@ class MockUSBServoBoardDevice(usb.core.Device):
         """Set the value of a servo."""
         assert -100 <= wValue <= 100
         assert data == b''
+        assert self.timers_initialised
 
 
 def mock_find(


### PR DESCRIPTION
Fixes #312

There are a couple of `type: ignore`s in the tests. This is due to deliberately passing in a broken type, as students may not run a type checker.