### PR TITLE
Fix mutability issues on components

### DIFF
--- a/j5/boards/sb/arduino.py
+++ b/j5/boards/sb/arduino.py
@@ -13,6 +13,7 @@ from j5.components import (
     LEDInterface,
 )
 from j5.components.derived import UltrasoundInterface, UltrasoundSensor
+from j5.types import ImmutableDict
 
 
 class AnaloguePin(IntEnum):
@@ -92,13 +93,13 @@ class SBArduinoBoard(Board):
         return self._backend.firmware_version
 
     @property
-    def pins(self) -> Mapping[PinNumber, GPIOPin]:
+    def pins(self) -> ImmutableDict[PinNumber, GPIOPin]:
         """Get the GPIO pins."""
-        pins: Mapping[PinNumber, GPIOPin] = {
+        pins = ImmutableDict[PinNumber, GPIOPin]({
             **cast(Mapping[PinNumber, GPIOPin], self._analogue_pins),
             **cast(Mapping[PinNumber, GPIOPin], self._digital_pins),
 
-        }
+        })
         return pins
 
     def make_safe(self) -> None:

--- a/j5/boards/sr/v4/motor_board.py
+++ b/j5/boards/sr/v4/motor_board.py
@@ -1,9 +1,10 @@
 """Classes for the SR v4 Motor Board."""
-from typing import TYPE_CHECKING, Optional, Set, Tuple, Type, cast
+from typing import TYPE_CHECKING, Optional, Set, Type, cast
 
 from j5.backends import Backend
 from j5.boards import Board
 from j5.components.motor import Motor, MotorInterface, MotorSpecialState
+from j5.types import ImmutableList
 
 if TYPE_CHECKING:  # pragma: no cover
     from j5.components import (  # noqa: F401
@@ -20,7 +21,7 @@ class MotorBoard(Board):
         self._serial = serial
         self._backend = backend
 
-        self._outputs: Tuple[Motor] = (
+        self._outputs = ImmutableList[Motor](
             Motor(output, cast(MotorInterface, self._backend))
             for output in range(0, 2)
         )
@@ -36,7 +37,7 @@ class MotorBoard(Board):
         return self._backend.firmware_version
 
     @property
-    def motors(self) -> Tuple[Motor]:
+    def motors(self) -> ImmutableList[Motor]:
         """Get the motors on this board."""
         return self._outputs
 

--- a/j5/boards/sr/v4/motor_board.py
+++ b/j5/boards/sr/v4/motor_board.py
@@ -1,5 +1,5 @@
 """Classes for the SR v4 Motor Board."""
-from typing import TYPE_CHECKING, List, Optional, Set, Type, cast
+from typing import TYPE_CHECKING, Optional, Set, Tuple, Type, cast
 
 from j5.backends import Backend
 from j5.boards import Board
@@ -20,10 +20,10 @@ class MotorBoard(Board):
         self._serial = serial
         self._backend = backend
 
-        self._outputs: List[Motor] = [
+        self._outputs: Tuple[Motor] = (
             Motor(output, cast(MotorInterface, self._backend))
             for output in range(0, 2)
-        ]
+        )
 
     @property
     def serial(self) -> str:
@@ -36,7 +36,7 @@ class MotorBoard(Board):
         return self._backend.firmware_version
 
     @property
-    def motors(self) -> List[Motor]:
+    def motors(self) -> Tuple[Motor]:
         """Get the motors on this board."""
         return self._outputs
 

--- a/j5/boards/sr/v4/servo_board.py
+++ b/j5/boards/sr/v4/servo_board.py
@@ -1,9 +1,10 @@
 """Classes for the SR v4 Servo Board."""
-from typing import TYPE_CHECKING, Optional, Set, Tuple, Type, cast
+from typing import TYPE_CHECKING, Optional, Set, Type, cast
 
 from j5.backends import Backend
 from j5.boards import Board
 from j5.components.servo import Servo, ServoInterface
+from j5.types import ImmutableList
 
 if TYPE_CHECKING:  # pragma: no cover
     from j5.components import (  # noqa: F401
@@ -20,7 +21,7 @@ class ServoBoard(Board):
         self._serial = serial
         self._backend = backend
 
-        self._servos: Tuple[Servo] = (
+        self._servos = ImmutableList[Servo](
             Servo(servo, cast(ServoInterface, self._backend))
             for servo in range(0, 12)
         )
@@ -49,6 +50,6 @@ class ServoBoard(Board):
         return {Servo}
 
     @property
-    def servos(self) -> Tuple[Servo]:
+    def servos(self) -> ImmutableList[Servo]:
         """Get the servos on this board."""
         return self._servos

--- a/j5/boards/sr/v4/servo_board.py
+++ b/j5/boards/sr/v4/servo_board.py
@@ -1,5 +1,5 @@
 """Classes for the SR v4 Servo Board."""
-from typing import TYPE_CHECKING, List, Optional, Set, Type, cast
+from typing import TYPE_CHECKING, Optional, Set, Tuple, Type, cast
 
 from j5.backends import Backend
 from j5.boards import Board
@@ -20,10 +20,10 @@ class ServoBoard(Board):
         self._serial = serial
         self._backend = backend
 
-        self._servos: List[Servo] = [
+        self._servos: Tuple[Servo] = (
             Servo(servo, cast(ServoInterface, self._backend))
             for servo in range(0, 12)
-        ]
+        )
 
     @property
     def serial(self) -> str:
@@ -49,6 +49,6 @@ class ServoBoard(Board):
         return {Servo}
 
     @property
-    def servos(self) -> List[Servo]:
+    def servos(self) -> Tuple[Servo]:
         """Get the servos on this board."""
         return self._servos

--- a/j5/types.py
+++ b/j5/types.py
@@ -1,5 +1,5 @@
 """Useful datatypes that aren't available in the standard lib."""
-from typing import Generic, Iterator, Mapping, TypeVar
+from typing import Generator, Generic, Iterator, List, Mapping, TypeVar, Union
 
 T = TypeVar("T")
 U = TypeVar("U")
@@ -18,6 +18,25 @@ class ImmutableDict(Generic[T, U]):
     def __iter__(self) -> Iterator[U]:
         """Iterate over the members of the group."""
         return iter(self._members.values())
+
+    def __len__(self) -> int:
+        """Get the number of members in the group."""
+        return len(self._members)
+
+
+class ImmutableList(Generic[T]):
+    """A list whose items cannot be set."""
+
+    def __init__(self, members: Union[List[T], Generator[T, None, None]]):
+        self._members: List[T] = list(members)
+
+    def __getitem__(self, index: int) -> T:
+        """Get an member using list notation."""
+        return self._members[index]
+
+    def __iter__(self) -> Iterator[T]:
+        """Iterate over the members of the group."""
+        return iter(self._members)
 
     def __len__(self) -> int:
         """Get the number of members in the group."""

--- a/j5/types.py
+++ b/j5/types.py
@@ -1,0 +1,24 @@
+"""Useful datatypes that aren't available in the standard lib."""
+from typing import Generic, Iterator, Mapping, TypeVar
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+
+class ImmutableDict(Generic[T, U]):
+    """A dictionary whose elements cannot be set."""
+
+    def __init__(self, members: Mapping[T, U]):
+        self._members = members
+
+    def __getitem__(self, index: T) -> U:
+        """Get an member using list notation."""
+        return self._members[index]
+
+    def __iter__(self) -> Iterator[U]:
+        """Iterate over the members of the group."""
+        return iter(self._members.values())
+
+    def __len__(self) -> int:
+        """Get the number of members in the group."""
+        return len(self._members)

--- a/tests/boards/sb/test_arduino.py
+++ b/tests/boards/sb/test_arduino.py
@@ -3,6 +3,8 @@
 from datetime import timedelta
 from typing import TYPE_CHECKING, Optional, Set
 
+import pytest
+
 from j5.backends import Backend
 from j5.boards.sb import AnaloguePin, SBArduinoBoard
 from j5.components import GPIOPin, GPIOPinInterface, GPIOPinMode, LEDInterface
@@ -146,3 +148,15 @@ def test_uno_ultrasound_sensors() -> None:
     assert type(sensor) is UltrasoundSensor
     assert sensor._gpio_trigger._identifier == 3
     assert sensor._gpio_echo._identifier == 4
+
+
+def test_pin_mutability() -> None:
+    """
+    Test the mutability of GPIOPins.
+
+    Ensures that GPIOPin objects cannot be lost.
+    """
+    uno = SBArduinoBoard("SERIAL0", MockSBArduinoBackend())
+
+    with pytest.raises(TypeError):
+        uno.pins[2] = True  # type: ignore

--- a/tests/boards/sr/v4/test_motor_board.py
+++ b/tests/boards/sr/v4/test_motor_board.py
@@ -1,6 +1,8 @@
 """Tests for the SR v4 Motor Board."""
 from typing import List, Optional, Set
 
+import pytest
+
 from j5.backends import Backend
 from j5.boards import Board
 from j5.boards.sr.v4 import MotorBoard
@@ -97,3 +99,15 @@ def test_motor_board_motors() -> None:
 
     for m in mb.motors:
         assert type(m) is Motor
+
+
+def test_motor_mutability() -> None:
+    """
+    Test the mutability of Motors.
+
+    Ensures that Motor objects cannot be lost.
+    """
+    mb = MotorBoard("SERIAL0", MockMotorBoardBackend())
+
+    with pytest.raises(TypeError):
+        mb.motors[1] = 1  # type: ignore

--- a/tests/boards/sr/v4/test_power_board.py
+++ b/tests/boards/sr/v4/test_power_board.py
@@ -2,6 +2,8 @@
 from datetime import timedelta
 from typing import TYPE_CHECKING, Optional, Set
 
+import pytest
+
 from j5.backends import Backend
 from j5.boards.sr.v4 import PowerBoard, PowerOutputGroup, PowerOutputPosition
 from j5.components import (
@@ -181,3 +183,15 @@ def test_power_board_wait_start() -> None:
     pb.wait_for_start_flash()
 
     assert pb._run_led.state
+
+
+def test_output_mutability() -> None:
+    """
+    Test the mutability of Motors.
+
+    Ensures that Motor objects cannot be lost.
+    """
+    pb = PowerBoard("SERIAL0", MockPowerBoardBackend())
+
+    with pytest.raises(TypeError):
+        pb.outputs[PowerOutputPosition.L0] = True  # type: ignore

--- a/tests/boards/sr/v4/test_power_board.py
+++ b/tests/boards/sr/v4/test_power_board.py
@@ -187,9 +187,9 @@ def test_power_board_wait_start() -> None:
 
 def test_output_mutability() -> None:
     """
-    Test the mutability of Motors.
+    Test the mutability of outputs.
 
-    Ensures that Motor objects cannot be lost.
+    Ensures that Output objects cannot be lost.
     """
     pb = PowerBoard("SERIAL0", MockPowerBoardBackend())
 

--- a/tests/boards/sr/v4/test_servo_board.py
+++ b/tests/boards/sr/v4/test_servo_board.py
@@ -1,6 +1,8 @@
 """Tests for the SR v4 Servo Board."""
 from typing import List, Optional, Set
 
+import pytest
+
 from j5.backends import Backend
 from j5.boards import Board
 from j5.boards.sr.v4 import ServoBoard
@@ -85,3 +87,15 @@ def test_servo_board_servos() -> None:
     sb = ServoBoard("SERIAL0", MockServoBoardBackend())
 
     assert all(type(s) is Servo for s in sb.servos)
+
+
+def test_servo_mutability() -> None:
+    """
+    Test the mutability of Motors.
+
+    Ensures that Motor objects cannot be lost.
+    """
+    sb = ServoBoard("SERIAL0", MockServoBoardBackend())
+
+    with pytest.raises(TypeError):
+        sb.servos[1] = 0.5  # type: ignore

--- a/tests/boards/sr/v4/test_servo_board.py
+++ b/tests/boards/sr/v4/test_servo_board.py
@@ -91,9 +91,9 @@ def test_servo_board_servos() -> None:
 
 def test_servo_mutability() -> None:
     """
-    Test the mutability of Motors.
+    Test the mutability of Servos.
 
-    Ensures that Motor objects cannot be lost.
+    Ensures that Servo objects cannot be lost.
     """
     sb = ServoBoard("SERIAL0", MockServoBoardBackend())
 

--- a/tests/boards/test_board_group.py
+++ b/tests/boards/test_board_group.py
@@ -223,3 +223,15 @@ def test_board_group_make_safe() -> None:
     assert not any(board._safe for board in board_group)
     board_group.make_safe()
     assert all(board._safe for board in board_group)
+
+
+def test_board_group_mutability() -> None:
+    """
+    Test that the members of BoardGroup are immutable.
+
+    This is to try and ensure that an error would be thrown on a student typo.
+    """
+    board_group = BoardGroup.get_board_group(MockBoard, TwoBoardsMockBackend)
+
+    with pytest.raises(TypeError):
+        board_group["TESTSERIAL1"] = 12  # type: ignore

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,27 @@
+"""Test custom types."""
+from j5.types import ImmutableDict
+
+
+def test_immutable_dict_get_member() -> None:
+    """Test that we can get an item from an ImmutableDict."""
+    d = ImmutableDict[str, str]({'foo': 'bar'})
+
+    assert d['foo'] == 'bar'
+
+
+def test_immutable_dict_iterator() -> None:
+    """Test that the iterator works."""
+    data = {'foo': 'bar', 'bar': 'doo', 'doo': 'foo'}
+
+    d = ImmutableDict(data)
+
+    assert [item for item in d] == [item for item in data.values()]
+
+
+def test_immutable_dict_length() -> None:
+    """Test that the length operation works."""
+    data = {'foo': 'bar', 'bar': 'doo', 'doo': 'foo'}
+
+    d = ImmutableDict(data)
+
+    assert len(d) == 3

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -59,10 +59,10 @@ def test_immutable_list_get_item() -> None:
     assert li[-1] == 2
 
     with pytest.raises(IndexError):
-        li[7]
+        assert li[7]
 
     with pytest.raises(TypeError):
-        li["foo"]  # type:ignore
+        assert li["foo"]  # type:ignore
 
 
 def test_immutable_list_length() -> None:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,7 @@
 """Test custom types."""
-from j5.types import ImmutableDict
+import pytest
+
+from j5.types import ImmutableDict, ImmutableList
 
 
 def test_immutable_dict_get_member() -> None:
@@ -12,16 +14,69 @@ def test_immutable_dict_get_member() -> None:
 def test_immutable_dict_iterator() -> None:
     """Test that the iterator works."""
     data = {'foo': 'bar', 'bar': 'doo', 'doo': 'foo'}
-
     d = ImmutableDict(data)
 
-    assert [item for item in d] == [item for item in data.values()]
+    assert list(d) == list(data.values())
 
 
 def test_immutable_dict_length() -> None:
     """Test that the length operation works."""
     data = {'foo': 'bar', 'bar': 'doo', 'doo': 'foo'}
-
     d = ImmutableDict(data)
 
     assert len(d) == 3
+
+
+def test_immutable_dict_cannot_set_member() -> None:
+    """Test that the immutable dict is immutable."""
+    data = {'foo': 'bar', 'bar': 'doo', 'doo': 'foo'}
+    d = ImmutableDict(data)
+
+    with pytest.raises(TypeError):
+        d['foo'] = '12'  # type: ignore
+
+
+def test_immutable_list_construct_from_list() -> None:
+    """Test that we can construct an ImmutableList from a list."""
+    data = [1, 3, 4, 6, 2]
+    li = ImmutableList[int](data)
+    assert list(li) == data
+
+
+def test_immutable_list_construct_from_generator() -> None:
+    """Test that we can construct an ImmutableList from a generator."""
+    data = [1, 3, 4, 6, 2]
+    li = ImmutableList[int](item for item in data)
+    assert list(li) == data
+
+
+def test_immutable_list_get_item() -> None:
+    """Test that we can get an item from an ImmutableList."""
+    data = [1, 3, 4, 6, 2]
+    li = ImmutableList[int](data)
+
+    assert li[0] == 1
+    assert li[-1] == 2
+
+    with pytest.raises(IndexError):
+        li[7]
+
+    with pytest.raises(TypeError):
+        li["foo"]  # type:ignore
+
+
+def test_immutable_list_length() -> None:
+    """Test that we can get the list length."""
+    data = [1, 3, 4, 6, 2]
+    li = ImmutableList[int](data)
+
+    assert len(li) == 5
+
+
+def test_immutable_list_cannot_set_item() -> None:
+    """Test that the list is not immutable."""
+    data = [1, 3, 4, 6, 2]
+    li = ImmutableList[int](data)
+
+    with pytest.raises(TypeError):
+        li[0] = 12  # type: ignore


### PR DESCRIPTION
Also test for this on BoardGroups too.

This PR changes some lists to tuples and some dicts to an immutable dict type.

The primary reason for this is for when the following student mistake is made:

```python
r.motor_boards[0].motors[0] = 100
```

Correct code:

```python
r.motor_boards[0].motors[0].power = 100
```

This is likely to occur a lot as it's similar to the old SR API.