### PR TITLE
Ensure that all outputs from zoloto are converted to python floats

### DIFF
--- a/j5/backends/hardware/zoloto/camera_board.py
+++ b/j5/backends/hardware/zoloto/camera_board.py
@@ -67,10 +67,10 @@ class ZolotoCameraBoardHardwareBackend(
 
         for zmarker in marker_gen:
             position = Coordinate(
-                # Convert to metres
-                zmarker.cartesian.x / 100,
-                zmarker.cartesian.y / 100,
-                zmarker.cartesian.z / 100,
+                # Convert to metres and python floats
+                float(zmarker.cartesian.x / 100),
+                float(zmarker.cartesian.y / 100),
+                float(zmarker.cartesian.z / 100),
             )
             orientation = Orientation(zmarker.orientation.quaternion)
             pixel_corners = list(

--- a/j5/vision/orientation.py
+++ b/j5/vision/orientation.py
@@ -28,9 +28,9 @@ class Orientation:
         """
         r_m = self._quaternion.rotation_matrix
         return (
-            (r_m[0][0], r_m[0][1], r_m[0][2]),
-            (r_m[1][0], r_m[1][1], r_m[1][2]),
-            (r_m[2][0], r_m[2][1], r_m[2][2]),
+            (float(r_m[0][0]), float(r_m[0][1]), float(r_m[0][2])),
+            (float(r_m[1][0]), float(r_m[1][1]), float(r_m[1][2])),
+            (float(r_m[2][0]), float(r_m[2][1]), float(r_m[2][2])),
         )
 
     @property
@@ -42,22 +42,22 @@ class Orientation:
 
         See pyquaternion for details.
         """
-        return self._quaternion.yaw_pitch_roll
+        return self.yaw, self.pitch, self.roll
 
     @property
     def yaw(self) -> float:
         """Rotation angle around the z-axis in radians."""
-        return self.yaw_pitch_roll[0]
+        return float(self.yaw_pitch_roll[0])
 
     @property
     def pitch(self) -> float:
         """Rotation angle around the y'-axis in radians."""
-        return self.yaw_pitch_roll[1]
+        return float(self.yaw_pitch_roll[1])
 
     @property
     def roll(self) -> float:
         """Rotation angle around the x''-axis in radians."""
-        return self.yaw_pitch_roll[2]
+        return float(self.yaw_pitch_roll[2])
 
     @property
     def rot_x(self) -> float:

--- a/j5/vision/orientation.py
+++ b/j5/vision/orientation.py
@@ -47,17 +47,17 @@ class Orientation:
     @property
     def yaw(self) -> float:
         """Rotation angle around the z-axis in radians."""
-        return float(self.yaw_pitch_roll[0])
+        return float(self.quaternion.yaw_pitch_roll[0])
 
     @property
     def pitch(self) -> float:
         """Rotation angle around the y'-axis in radians."""
-        return float(self.yaw_pitch_roll[1])
+        return float(self.quaternion.yaw_pitch_roll[1])
 
     @property
     def roll(self) -> float:
         """Rotation angle around the x''-axis in radians."""
-        return float(self.yaw_pitch_roll[2])
+        return float(self.quaternion.yaw_pitch_roll[2])
 
     @property
     def rot_x(self) -> float:


### PR DESCRIPTION
## Checklist

- [x] I have updated the relevant documentation
- [x] I have added the `semver-major`, `semver-minor` or `semver-patch` label as appropriate
- [ ] I would like multiple reviewers to approve my code before merging

## Why do you want to make these changes?

We need to try and convert numpy c floats to python floats to prevent expected type errors.

This somewhat suggests that there is an issue with the numpy-stubs that we are using :/

## Which parts of the codebase do your changes affect?

Zoloto driver and Orientation class when access pyquaternion

## How do your changes affect student or volunteer experience?

Likely entirely unnoticed

## Are your changes related to any existing issues or PRs? How so?

Fixes #548