### PR TITLE
Add Backend as superclass of SerialHardwareBackend

### DIFF
--- a/j5/backends/hardware/j5/serial.py
+++ b/j5/backends/hardware/j5/serial.py
@@ -6,7 +6,7 @@ from typing import Optional, Set, Type
 from serial import Serial, SerialException, SerialTimeoutException
 from typing_extensions import Protocol
 
-from j5.backends import BackendMeta, CommunicationError
+from j5.backends import Backend, BackendMeta, CommunicationError
 from j5.boards import Board
 
 
@@ -43,7 +43,7 @@ class Seriallike(Protocol):
         ...  # pragma: nocover
 
 
-class SerialHardwareBackend(metaclass=BackendMeta):
+class SerialHardwareBackend(Backend, metaclass=BackendMeta):
     """An abstract class for creating backends that use USB serial communication."""
 
     DEFAULT_TIMEOUT: timedelta = timedelta(milliseconds=250)

--- a/j5/backends/hardware/sb/arduino.py
+++ b/j5/backends/hardware/sb/arduino.py
@@ -71,7 +71,7 @@ class SBArduinoHardwareBackend(
             boards.add(
                 SBArduinoBoard(
                     port.serial_number,
-                    cls(port.device, serial_class),  # type: ignore
+                    cls(port.device, serial_class),
                 ),
             )
 


### PR DESCRIPTION
Spotted by @sersorrel in https://github.com/srobo/sr-robot3/pull/2#discussion_r449811261

This also means that the abstract methods are now actually enforced.

We should consider introducing a run-time type check for this, but I am
unable to think of a good place to put it at the moment.

## Checklist

- [x] I have updated the relevant documentation
- [x] I have added the `semver-major`, `semver-minor` or `semver-patch` label as appropriate
- [ ] I would like multiple reviewers to approve my code before merging

## Why do you want to make these changes?

Stops need to cast to `Type[Backend]` in environment definitions.
## Which parts of the codebase do your changes affect?

`SerialHardwareBackend` and subclasses thereof, `SRV4MotorBoardBackend`, `SBArduinoHardwareBackend`

## How do your changes affect student or volunteer experience?

Shouldn't make any difference. This is purely for typing

## Are your changes related to any existing issues or PRs? How so?

We had previously attributed this bug to #489, although didn't have an open issue for it :/