### PR TITLE
Use explicit methods for controlling GPIOPin

### DIFF
--- a/j5/components/gpio_pin.py
+++ b/j5/components/gpio_pin.py
@@ -187,22 +187,27 @@ class GPIOPin(Component):
         """Set the analogue value of the pin."""
         self._require_pin_modes({
             GPIOPinMode.ANALOGUE_OUTPUT,
-            GPIOPinMode.PWM_OUTPUT,
         })
         if new_value < 0 or new_value > 1:
             raise ValueError("An analogue pin value must be between 0 and 1.")
 
-        if self.mode is GPIOPinMode.ANALOGUE_OUTPUT:
-            self._backend.write_gpio_pin_dac_value(
-                self._identifier,
-                new_value,
-            )
-        else:
-            # We must be a PWM_OUTPUT
-            self._backend.write_gpio_pin_pwm_value(
-                self._identifier,
-                new_value,
-            )
+        self._backend.write_gpio_pin_dac_value(
+            self._identifier,
+            new_value,
+        )
+
+    def pwm_write(self, new_value: float) -> None:
+        """Set the PWM value of the pin."""
+        self._require_pin_modes({
+            GPIOPinMode.PWM_OUTPUT,
+        })
+        if new_value < 0 or new_value > 1:
+            raise ValueError("An PWM pin value must be between 0 and 1.")
+
+        self._backend.write_gpio_pin_pwm_value(
+            self._identifier,
+            new_value,
+        )
 
     @property
     def firmware_modes(self) -> Set[FirmwareMode]:

--- a/j5/components/gpio_pin.py
+++ b/j5/components/gpio_pin.py
@@ -152,36 +152,38 @@ class GPIOPin(Component):
         if isinstance(pin_mode, GPIOPinMode):
             self._backend.set_gpio_pin_mode(self._identifier, pin_mode)
 
-    @property
-    def digital_state(self) -> bool:
-        """Get the digital state of the pin."""
-        self._require_pin_modes({
-            GPIOPinMode.DIGITAL_OUTPUT,
-            GPIOPinMode.DIGITAL_INPUT,
-            GPIOPinMode.DIGITAL_INPUT_PULLUP,
-            GPIOPinMode.DIGITAL_INPUT_PULLDOWN},
-        )
-
-        # Behave differently depending on the hardware mode.
-        if self.mode is GPIOPinMode.DIGITAL_OUTPUT:
-            return self._backend.get_gpio_pin_digital_state(self._identifier)
-
-        return self._backend.read_gpio_pin_digital_state(self._identifier)
-
-    @digital_state.setter
-    def digital_state(self, state: bool) -> None:
+    def digital_write(self, state: bool) -> None:
         """Set the digital state of the pin."""
         self._require_pin_modes({GPIOPinMode.DIGITAL_OUTPUT})
         self._backend.write_gpio_pin_digital_state(self._identifier, state)
 
     @property
-    def analogue_value(self) -> float:
+    def last_digital_write(self) -> bool:
+        """
+        Get the last set digital state of the pin.
+
+        This does not perform a read operation, it only gets the last set
+        value, which is usually cached in memory.
+        """
+        self._require_pin_modes({GPIOPinMode.DIGITAL_OUTPUT})
+        return self._backend.get_gpio_pin_digital_state(self._identifier)
+
+    def digital_read(self) -> bool:
+        """Get the digital state of the pin."""
+        self._require_pin_modes({
+            GPIOPinMode.DIGITAL_INPUT,
+            GPIOPinMode.DIGITAL_INPUT_PULLUP,
+            GPIOPinMode.DIGITAL_INPUT_PULLDOWN},
+        )
+
+        return self._backend.read_gpio_pin_digital_state(self._identifier)
+
+    def analogue_read(self) -> float:
         """Get the scaled analogue reading of the pin."""
         self._require_pin_modes({GPIOPinMode.ANALOGUE_INPUT})
         return self._backend.read_gpio_pin_analogue_value(self._identifier)
 
-    @analogue_value.setter
-    def analogue_value(self, new_value: float) -> None:
+    def analogue_write(self, new_value: float) -> None:
         """Set the analogue value of the pin."""
         self._require_pin_modes({
             GPIOPinMode.ANALOGUE_OUTPUT,

--- a/tests/components/test_gpio_pin.py
+++ b/tests/components/test_gpio_pin.py
@@ -317,11 +317,27 @@ def test_analogue_value_setter() -> None:
     pin.mode = GPIOPinMode.ANALOGUE_OUTPUT
     pin.analogue_write(0.6)
 
-    pin.mode = GPIOPinMode.PWM_OUTPUT
-    pin.analogue_write(0.7)
-
     with pytest.raises(ValueError):
         pin.analogue_write(-1)
+
+
+def test_pwm_value_setter() -> None:
+    """Test that we can set a scaled PWM value."""
+    driver = MockGPIOPinDriver()
+    pin = GPIOPin(
+        0,
+        driver,
+        initial_mode=GPIOPinMode.PWM_OUTPUT,
+        hardware_modes={
+            GPIOPinMode.PWM_OUTPUT,
+        },
+    )
+
+    pin.mode = GPIOPinMode.PWM_OUTPUT
+    pin.pwm_write(0.7)
+
+    with pytest.raises(ValueError):
+        pin.pwm_write(-1)
 
 
 class Peripheral(DerivedComponent):

--- a/tests/components/test_gpio_pin.py
+++ b/tests/components/test_gpio_pin.py
@@ -233,9 +233,12 @@ def test_digital_state_getter() -> None:
 
     # Digital Output
     pin.mode = GPIOPinMode.DIGITAL_OUTPUT
-    assert pin.digital_state is driver._written_digital_state[0]
+    assert pin.last_digital_write is driver._written_digital_state[0]
     driver._written_digital_state[0] = not driver._written_digital_state[0]
-    assert pin.digital_state is driver._written_digital_state[0]
+    assert pin.last_digital_write is driver._written_digital_state[0]
+
+    with pytest.raises(BadGPIOPinModeError):
+        _ = pin.digital_read()
 
     # Digital Input
     for mode in [
@@ -244,14 +247,14 @@ def test_digital_state_getter() -> None:
         GPIOPinMode.DIGITAL_INPUT_PULLDOWN,
     ]:
         pin.mode = mode
-        assert pin.digital_state is driver._digital_state[0]
+        assert pin.digital_read() is driver._digital_state[0]
         driver._digital_state[0] = not driver._digital_state[0]
-        assert pin.digital_state is driver._digital_state[0]
+        assert pin.digital_read() is driver._digital_state[0]
 
     # Analogue
     pin.mode = GPIOPinMode.ANALOGUE_INPUT
     with pytest.raises(BadGPIOPinModeError):
-        _ = pin.digital_state
+        _ = pin.last_digital_write
 
 
 def test_digital_state_setter() -> None:
@@ -270,9 +273,9 @@ def test_digital_state_setter() -> None:
     )
 
     pin.mode = GPIOPinMode.DIGITAL_OUTPUT
-    pin.digital_state = True
+    pin.digital_write(True)
     assert driver._written_digital_state[0]
-    pin.digital_state = False
+    pin.digital_write(False)
     assert not driver._written_digital_state[0]
 
 
@@ -291,11 +294,11 @@ def test_analogue_value_getter() -> None:
         },
     )
     pin.mode = GPIOPinMode.ANALOGUE_INPUT
-    assert pin.analogue_value == 0.6
+    assert pin.analogue_read() == 0.6
 
     with pytest.raises(BadGPIOPinModeError):
         pin.mode = GPIOPinMode.DIGITAL_OUTPUT
-        _ = pin.analogue_value
+        _ = pin.analogue_read()
 
 
 def test_analogue_value_setter() -> None:
@@ -312,13 +315,13 @@ def test_analogue_value_setter() -> None:
     )
 
     pin.mode = GPIOPinMode.ANALOGUE_OUTPUT
-    pin.analogue_value = 0.6
+    pin.analogue_write(0.6)
 
     pin.mode = GPIOPinMode.PWM_OUTPUT
-    pin.analogue_value = 0.7
+    pin.analogue_write(0.7)
 
     with pytest.raises(ValueError):
-        pin.analogue_value = -1
+        pin.analogue_write(-1)
 
 
 class Peripheral(DerivedComponent):

--- a/tests_hw/test_sb_arduino.py
+++ b/tests_hw/test_sb_arduino.py
@@ -31,20 +31,20 @@ if __name__ == '__main__':
     print("Setting all pins high.")
     for pin in range(2, 14):
         r.arduino.pins[pin].mode = GPIOPinMode.DIGITAL_OUTPUT
-        r.arduino.pins[pin].digital_state = True
+        r.arduino.pins[pin].digital_write(True)
 
     sleep(1)
 
     print("Setting all pins low.")
     for pin in range(2, 14):
         r.arduino.pins[pin].mode = GPIOPinMode.DIGITAL_OUTPUT
-        r.arduino.pins[pin].digital_state = False
+        r.arduino.pins[pin].digital_write(False)
 
     sleep(1)
 
     for pin in range(2, 14):
         r.arduino.pins[pin].mode = GPIOPinMode.DIGITAL_INPUT
-        print(f"Pin {pin} digital state = {r.arduino.pins[pin].digital_state}")
+        print(f"Pin {pin} digital state = {r.arduino.pins[pin].digital_read()}")
     for pin in range(14, 18):
         r.arduino.pins[pin].mode = GPIOPinMode.ANALOGUE_INPUT
-        print(f"Pin {pin} analogue voltage = {r.arduino.pins[pin].analogue_value}")
+        print(f"Pin {pin} analogue voltage = {r.arduino.pins[pin].analogue_read()}")


### PR DESCRIPTION
Adds following methods:

- `digital_write`
- `digital_read`
- `analogue_write`
- `analogue_read`

Also `last_digital_write` property.

These replace the previous behaviours of `digital_state` and
`analogue_value`.

## Checklist

- [x] I have updated the relevant documentation
- [x] I have added the `semver-major`, `semver-minor` or `semver-patch` label as appropriate
- [x] I would like multiple reviewers to approve my code before merging

## Why do you want to make these changes?

Previous ways to control the `GPIOPin` component were designed to be very consistent with other parts of the API, for example on the `Motor` component, where property setters and getters are used heavily.

This resulted in confusing functionality, where the same property would behave differently depending on the `mode` of the `GPIOPin`, which will likely result in a high rate of student bugs. For example:

```python

pin = r.ruggeduino.pins[3]

pin.mode = DIGITAL_WRITE

print(pin.digital_state)
```

```python

pin = r.ruggeduino.pins[3]

pin.mode = DIGITAL_READ

print(pin.digital_state)
```

Both of these snippets are very similar, both will print either `True` or `False`. However, the first just reads the cached last set state, and the latter actually performs a digital read.

## Which parts of the codebase do your changes affect?

- `GPIOPin`, and its tests.
- `tests_hw/sb_arduino`

## How do your changes affect student or volunteer experience?

Previous functionality was confusing, where the same property would behave differently depending on the `mode` of the `GPIOPin`, which will likely result in a high rate of student bugs. 

## Are your changes related to any existing issues or PRs? How so?

Closes #592

These changes were also discussed by the SR Brain Team in a meeting on 2nd July, where it was concluded that the API should change. This new API is more similar to `sr-robot` and `robot-api` too.