### PR TITLE
Rename Board.serial to Board.serial_number

### DIFF
--- a/docs/_code/qs_adding_boards.py
+++ b/docs/_code/qs_adding_boards.py
@@ -24,7 +24,7 @@ class MyRobot(BaseRobot):
 
 r = MyRobot()
 
-print(f"Found Power Board: {r.power_board.serial}")
+print(f"Found Power Board: {r.power_board.serial_number}")
 print(f"Power Board Firmware: {r.power_board.firmware_version}")
 
 # Access a board specific function
@@ -34,7 +34,7 @@ print(f"Found {len(r.motor_boards)} Motor Board(s):")
 
 # Iterate over the boards in a board group
 for board in r.motor_boards:
-    print(f" - {board.serial} - Version {board.firmware_version}")
+    print(f" - {board.serial_number} - Version {board.firmware_version}")
 
 # Access board by serial number
 r.motor_boards["218312"].make_safe()

--- a/j5/boards/arduino/uno.py
+++ b/j5/boards/arduino/uno.py
@@ -98,7 +98,7 @@ class ArduinoUno(Board):
         }
 
     @property
-    def serial(self) -> str:
+    def serial_number(self) -> str:
         """Get the serial number."""
         return self._serial
 

--- a/j5/boards/board.py
+++ b/j5/boards/board.py
@@ -34,7 +34,7 @@ class Board(metaclass=ABCMeta):
 
     def __str__(self) -> str:
         """A string representation of this board."""
-        return f"{self.name} - {self.serial}"
+        return f"{self.name} - {self.serial_number}"
 
     def __new__(cls, *args, **kwargs):  # type: ignore
         """Ensure any instantiated board is added to the boards list."""
@@ -44,7 +44,7 @@ class Board(metaclass=ABCMeta):
 
     def __repr__(self) -> str:
         """A representation of this board."""
-        return f"<{self.__class__.__name__} serial={self.serial}>"
+        return f"<{self.__class__.__name__} serial_number={self.serial_number}>"
 
     @property
     @abstractmethod
@@ -54,7 +54,7 @@ class Board(metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def serial(self) -> str:
+    def serial_number(self) -> str:
         """The serial number of the board."""
         raise NotImplementedError  # pragma: no cover
 

--- a/j5/boards/board_group.py
+++ b/j5/boards/board_group.py
@@ -44,8 +44,8 @@ class BoardGroup(Generic[T, U]):
         """Update the boards in this group to see if new boards have been added."""
         self._boards.clear()
         discovered_boards = self._backend_class.discover()
-        for board in sorted(discovered_boards, key=lambda b: b.serial):
-            self._boards.update({board.serial: cast(T, board)})
+        for board in sorted(discovered_boards, key=lambda b: b.serial_number):
+            self._boards.update({board.serial_number: cast(T, board)})
 
     def singular(self) -> T:
         """If there is only a single board in the group, return that board."""
@@ -77,9 +77,9 @@ class BoardGroup(Generic[T, U]):
         """Get the number of boards in this group."""
         return len(self._boards)
 
-    def __contains__(self, serial: str) -> bool:
+    def __contains__(self, serial_number: str) -> bool:
         """Check if a board is in this group."""
-        return serial in self._boards
+        return serial_number in self._boards
 
     def __iter__(self) -> Iterator[T]:
         """
@@ -89,14 +89,16 @@ class BoardGroup(Generic[T, U]):
         """
         return iter(self._boards.values())
 
-    def __getitem__(self, serial: str) -> T:
+    def __getitem__(self, serial_number: str) -> T:
         """Get the board from serial."""
         try:
-            return self._boards[serial]
+            return self._boards[serial_number]
         except KeyError:
-            if type(serial) != str:
-                raise TypeError("Serial must be a string")
-            raise KeyError(f"Could not find a board with the serial {serial}")
+            if type(serial_number) != str:
+                raise TypeError("Serial number must be a string")
+            raise KeyError(
+                f"Could not find a board with the serial number {serial_number}",
+            )
 
     @property
     def backend_class(self) -> Type[U]:

--- a/j5/boards/board_group.py
+++ b/j5/boards/board_group.py
@@ -94,7 +94,7 @@ class BoardGroup(Generic[T, U]):
         try:
             return self._boards[serial_number]
         except KeyError:
-            if type(serial_number) != str:
+            if not isinstance(serial_number, str):
                 raise TypeError("Serial number must be a string")
             raise KeyError(
                 f"Could not find a board with the serial number {serial_number}",

--- a/j5/boards/sr/v4/motor_board.py
+++ b/j5/boards/sr/v4/motor_board.py
@@ -39,7 +39,7 @@ class MotorBoard(Board):
         )
 
     @property
-    def serial(self) -> str:
+    def serial_number(self) -> str:
         """Get the serial number."""
         return self._serial
 

--- a/j5/boards/sr/v4/power_board.py
+++ b/j5/boards/sr/v4/power_board.py
@@ -71,7 +71,7 @@ class PowerBoard(Board):
         self._error_led = LED(1, cast("LEDInterface", self._backend))
 
     @property
-    def serial(self) -> str:
+    def serial_number(self) -> str:
         """Get the serial number."""
         return self._serial
 

--- a/j5/boards/sr/v4/servo_board.py
+++ b/j5/boards/sr/v4/servo_board.py
@@ -27,7 +27,7 @@ class ServoBoard(Board):
         )
 
     @property
-    def serial(self) -> str:
+    def serial_number(self) -> str:
         """Get the serial number."""
         return self._serial
 

--- a/j5/boards/zoloto/camera_board.py
+++ b/j5/boards/zoloto/camera_board.py
@@ -19,7 +19,7 @@ class ZolotoCameraBoard(Board):
         self._camera = MarkerCamera(0, cast(MarkerCameraInterface, backend))
 
     @property
-    def serial(self) -> str:
+    def serial_number(self) -> str:
         """Get the serial number."""
         return self._serial
 

--- a/tests/backends/hardware/j5/test_raw_usb.py
+++ b/tests/backends/hardware/j5/test_raw_usb.py
@@ -51,7 +51,7 @@ class MockBoard(Board):
         return "Mock Board."
 
     @property
-    def serial(self) -> str:
+    def serial_number(self) -> str:
         """The serial number of the board."""
         return "N/A"
 

--- a/tests/backends/hardware/sr/v4/test_motor_board.py
+++ b/tests/backends/hardware/sr/v4/test_motor_board.py
@@ -132,7 +132,7 @@ def test_backend_discover() -> None:
     assert len(found_boards) == 2
     assert all(type(board) is MotorBoard for board in found_boards)
 
-    assert all((int(board.serial[6:])) < 2 for board in found_boards)
+    assert all((int(board.serial_number[6:])) < 2 for board in found_boards)
 
 
 def test_backend_send_command() -> None:

--- a/tests/backends/test_backend.py
+++ b/tests/backends/test_backend.py
@@ -30,7 +30,7 @@ def test_backend_has_required_interface() -> None:
             return "Test Board 2"
 
         @property
-        def serial(self) -> str:
+        def serial_number(self) -> str:
             """The serial number of the board."""
             return "TEST2"
 

--- a/tests/backends/utils.py
+++ b/tests/backends/utils.py
@@ -16,7 +16,7 @@ class MockBoard(Board):
         return "Test Board"
 
     @property
-    def serial(self) -> str:
+    def serial_number(self) -> str:
         """The serial number of the board."""
         return "TEST"
 
@@ -44,7 +44,7 @@ class Mock2Board(Board):
         return "Test Board 2"
 
     @property
-    def serial(self) -> str:
+    def serial_number(self) -> str:
         """The serial number of the board."""
         return "TEST2"
 

--- a/tests/boards/arduino/test_uno.py
+++ b/tests/boards/arduino/test_uno.py
@@ -92,11 +92,11 @@ def test_uno_name() -> None:
     assert uno.name == "Arduino Uno"
 
 
-def test_uno_serial() -> None:
-    """Test the serial attribute of the Uno."""
+def test_uno_serial_number() -> None:
+    """Test the serial_number attribute of the Uno."""
     uno = ArduinoUno("SERIAL0", MockArduinoUnoBackend())
 
-    assert uno.serial == "SERIAL0"
+    assert uno.serial_number == "SERIAL0"
 
 
 def test_uno_firmware_version() -> None:

--- a/tests/boards/sb/test_arduino.py
+++ b/tests/boards/sb/test_arduino.py
@@ -112,11 +112,11 @@ def test_uno_name() -> None:
     assert uno.name == "Arduino Uno"
 
 
-def test_uno_serial() -> None:
+def test_uno_serial_number() -> None:
     """Test the serial attribute of the Uno."""
     uno = SBArduinoBoard("SERIAL0", MockSBArduinoBackend())
 
-    assert uno.serial == "SERIAL0"
+    assert uno.serial_number == "SERIAL0"
 
 
 def test_uno_firmware_version() -> None:

--- a/tests/boards/sr/v4/test_motor_board.py
+++ b/tests/boards/sr/v4/test_motor_board.py
@@ -73,11 +73,11 @@ def test_motor_board_name() -> None:
     assert mb.name == "Student Robotics v4 Motor Board"
 
 
-def test_motor_board_serial() -> None:
+def test_motor_board_serial_number() -> None:
     """Test the serial attribute of the motor board."""
     mb = MotorBoard("SERIAL0", MockMotorBoardBackend())
 
-    assert mb.serial == "SERIAL0"
+    assert mb.serial_number == "SERIAL0"
 
 
 def test_motor_board_make_safe_default() -> None:

--- a/tests/boards/sr/v4/test_power_board.py
+++ b/tests/boards/sr/v4/test_power_board.py
@@ -108,11 +108,11 @@ def test_power_board_name() -> None:
     assert pb.name == "Student Robotics v4 Power Board"
 
 
-def test_power_board_serial() -> None:
+def test_power_board_serial_number() -> None:
     """Test the serial attribute of the PowerBoard."""
     pb = PowerBoard("SERIAL0", MockPowerBoardBackend())
 
-    assert pb.serial == "SERIAL0"
+    assert pb.serial_number == "SERIAL0"
 
 
 def test_firmware_version() -> None:

--- a/tests/boards/sr/v4/test_ruggeduino.py
+++ b/tests/boards/sr/v4/test_ruggeduino.py
@@ -97,11 +97,11 @@ def test_ruggeduino_name() -> None:
     assert ruggeduino.name == "Ruggeduino"
 
 
-def test_ruggeduino_serial() -> None:
-    """Test the serial attribute of the Ruggeduino."""
+def test_ruggeduino_serial_number() -> None:
+    """Test the serial_number attribute of the Ruggeduino."""
     ruggeduino = Ruggeduino("SERIAL0", MockRuggeduinoBackend())
 
-    assert ruggeduino.serial == "SERIAL0"
+    assert ruggeduino.serial_number == "SERIAL0"
 
 
 def test_ruggeduino_firmware_version() -> None:

--- a/tests/boards/sr/v4/test_servo_board.py
+++ b/tests/boards/sr/v4/test_servo_board.py
@@ -68,11 +68,11 @@ def test_servo_board_firmware_version() -> None:
     assert sb.firmware_version is None
 
 
-def test_servo_board_serial() -> None:
+def test_servo_board_serial_number() -> None:
     """Test the serial attribute of the servo board."""
     sb = ServoBoard("SERIAL0", MockServoBoardBackend())
 
-    assert sb.serial == "SERIAL0"
+    assert sb.serial_number == "SERIAL0"
 
 
 def test_servo_board_make_safe() -> None:

--- a/tests/boards/test_board.py
+++ b/tests/boards/test_board.py
@@ -36,7 +36,7 @@ def test_testing_board_serial_number() -> None:
     tb = MockBoard("TESTSERIAL1")
 
     assert tb.serial_number == "TESTSERIAL1"
-    assert type(tb.serial_number) == str
+    assert isinstance(tb.serial_number, str)
 
 
 def test_testing_board_str() -> None:

--- a/tests/boards/test_board.py
+++ b/tests/boards/test_board.py
@@ -31,12 +31,12 @@ def test_testing_board_name() -> None:
     assert type(tb.name) == str
 
 
-def test_testing_board_serial() -> None:
+def test_testing_board_serial_number() -> None:
     """Test the serial property of the board class."""
     tb = MockBoard("TESTSERIAL1")
 
-    assert tb.serial == "TESTSERIAL1"
-    assert type(tb.serial) == str
+    assert tb.serial_number == "TESTSERIAL1"
+    assert type(tb.serial_number) == str
 
 
 def test_testing_board_str() -> None:
@@ -49,7 +49,7 @@ def test_testing_board_str() -> None:
 def test_testing_board_repr() -> None:
     """Test the __repr__ method of the board class."""
     tb = MockBoard("TESTSERIAL1")
-    assert repr(tb) == "<MockBoard serial=TESTSERIAL1>"
+    assert repr(tb) == "<MockBoard serial_number=TESTSERIAL1>"
 
 
 def test_discover() -> None:

--- a/tests/boards/test_board_group.py
+++ b/tests/boards/test_board_group.py
@@ -119,9 +119,10 @@ def test_board_group_boards_zero() -> None:
 def test_board_group_board_by_serial_number() -> None:
     """Test that the boards property works with serial indices."""
     board_group = BoardGroup.get_board_group(MockBoard, OneBoardMockBackend)
-    assert type(
+    assert isinstance(
         board_group[list(board_group._boards.values())[0].serial_number],
-    ) == MockBoard
+        MockBoard,
+    )
 
 
 def test_board_group_board_by_unknown() -> None:

--- a/tests/boards/test_board_group.py
+++ b/tests/boards/test_board_group.py
@@ -116,10 +116,12 @@ def test_board_group_boards_zero() -> None:
         board_group._boards["SERIAL0"]
 
 
-def test_board_group_board_by_serial() -> None:
+def test_board_group_board_by_serial_number() -> None:
     """Test that the boards property works with serial indices."""
     board_group = BoardGroup.get_board_group(MockBoard, OneBoardMockBackend)
-    assert type(board_group[list(board_group._boards.values())[0].serial]) == MockBoard
+    assert type(
+        board_group[list(board_group._boards.values())[0].serial_number],
+    ) == MockBoard
 
 
 def test_board_group_board_by_unknown() -> None:
@@ -200,9 +202,9 @@ def test_board_group_iteration() -> None:
 def test_board_group_iteration_sorted_by_serial() -> None:
     """Test that the boards yielded by iterating over a BoardGroup are sorted."""
     board_group = BoardGroup.get_board_group(MockBoard, TwoBoardsMockBackend)
-    serials = [board.serial for board in board_group]
-    assert len(serials) == 2
-    assert serials[0] < serials[1]
+    serial_numbers = [board.serial_number for board in board_group]
+    assert len(serial_numbers) == 2
+    assert serial_numbers[0] < serial_numbers[1]
 
 
 def test_board_group_simultaneous_iteration() -> None:

--- a/tests/boards/utils.py
+++ b/tests/boards/utils.py
@@ -19,7 +19,7 @@ class MockBoard(Board):
         return "Testing Board"
 
     @property
-    def serial(self) -> str:
+    def serial_number(self) -> str:
         """Get the serial number of this board."""
         return self._serial
 

--- a/tests_hw/test_camera.py
+++ b/tests_hw/test_camera.py
@@ -54,7 +54,7 @@ if __name__ == '__main__':
 
     r = Robot()
 
-    print(f"Serial number: {r.camera_board.serial}")
+    print(f"Serial number: {r.camera_board.serial_number}")
     print(f"Firmware version: {r.camera_board.firmware_version}")
 
     while True:

--- a/tests_hw/test_motor_board.py
+++ b/tests_hw/test_motor_board.py
@@ -44,7 +44,7 @@ if __name__ == '__main__':
     print("Waiting for start button...")
     r.power_board.wait_for_start_flash()
 
-    print(f"Serial number: {r.motor_board.serial}")
+    print(f"Serial number: {r.motor_board.serial_number}")
     print(f"Firmware version: {r.motor_board.firmware_version}")
 
     for m in r.motor_board.motors:

--- a/tests_hw/test_power_board.py
+++ b/tests_hw/test_power_board.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
     print("Waiting for start button...")
     r.power_board.wait_for_start_flash()
 
-    print(f"Serial number: {r.power_board.serial}")
+    print(f"Serial number: {r.power_board.serial_number}")
     print(f"Firmware version: {r.power_board.firmware_version}")
 
     print(f"Battery voltage: {r.power_board.battery_sensor.voltage} V")

--- a/tests_hw/test_ruggeduino.py
+++ b/tests_hw/test_ruggeduino.py
@@ -30,7 +30,7 @@ if __name__ == '__main__':
 
     r = Robot()
 
-    print(f"Serial number: {r.arduino.serial}")
+    print(f"Serial number: {r.arduino.serial_number}")
     print(f"Firmware version: {r.arduino.firmware_version}")
 
     print("Setting all pins high.")

--- a/tests_hw/test_sb_arduino.py
+++ b/tests_hw/test_sb_arduino.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
 
     r = Robot()
 
-    print(f"Serial number: {r.arduino.serial}")
+    print(f"Serial number: {r.arduino.serial_number}")
     print(f"Firmware version: {r.arduino.firmware_version}")
 
     print("Setting all pins high.")

--- a/tests_hw/test_servo_board.py
+++ b/tests_hw/test_servo_board.py
@@ -43,7 +43,7 @@ if __name__ == '__main__':
     print("Waiting for start button...")
     r.power_board.wait_for_start_flash()
 
-    print(f"Serial Number: {r.servo_board.serial}")
+    print(f"Serial Number: {r.servo_board.serial_number}")
     print(f"Firmware version: {r.servo_board.firmware_version}")
 
     for servo in r.servo_board.servos:


### PR DESCRIPTION
## Checklist

- [x] I have updated the relevant documentation
- [x] I have added the `semver-major`, `semver-minor` or `semver-patch` label as appropriate
- [ ] I would like multiple reviewers to approve my code before merging

## Why do you want to make these changes?

- Makes the difference between a UART serial and serial number clear.
- Requested change from SR @j5api/brain-team 

## Which parts of the codebase do your changes affect?

Anything that uses a serial number

## How do your changes affect student or volunteer experience?

Makes the difference between a UART serial and serial number clear.

## Are your changes related to any existing issues or PRs? How so?

Fixes #593 