### PR TITLE
tools: Fix git tag matching utility

### DIFF
--- a/tools/verify_git_version.py
+++ b/tools/verify_git_version.py
@@ -34,7 +34,15 @@ def find_version(*file_paths: str) -> str:
 
 def run() -> None:
     """Check the git version matches the j5 version."""
-    tag = os.getenv("GITHUB_REF")
+    tag_ref = os.getenv("GITHUB_REF") or "ENV NOT SET"
+
+    tag_match = re.match(r"ref/tags/(.+)", tag_ref)
+
+    if tag_match:
+        tag, = tag_match.groups()
+    else:
+        print(f"Git Ref {tag_ref} did not match expected format!")
+        tag = "UNKNOWN"
 
     VERSION = find_version("j5", "__init__.py")
 


### PR DESCRIPTION
This previously assumed that GitHub was handing us the tag rather than the ref, which caused the auto-deploy to fail for 0.12.0

## Checklist

- [x] I have updated the relevant documentation
- [x] I have added the `semver-major`, `semver-minor` or `semver-patch` label as appropriate
- [ ] I would like multiple reviewers to approve my code before merging

## Why do you want to make these changes?

So that CD works!

## Which parts of the codebase do your changes affect?

N/A

## How do your changes affect student or volunteer experience?

Auto deployment to PyPI

## Are your changes related to any existing issues or PRs? How so?

#54 