### PR TITLE
ci: Stop testing on Python 3.6

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.6
+      - name: Set up Python 3.7
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: 3.7
       - name: Install Poetry
         run: pip install poetry
       - name: Use in-project virtualenv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python: [3.6, 3.7, 3.8, 3.9]
+        python: [3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python }}

--- a/docs/usage/installation.rst
+++ b/docs/usage/installation.rst
@@ -5,7 +5,7 @@ Installation
 
 You will need the following installed on your machine:
 
-- Python_ 3.6 or higher
+- Python_ 3.7 or higher (Python 3.6 is supported, but no longer tested)
 - python3-pip (for package management)
 - pipenv_ (optional)
 


### PR DESCRIPTION
## Checklist

- [x] I have updated the relevant documentation
- [x] I have added the `semver-major`, `semver-minor` or `semver-patch` label as appropriate
- [x] I would like multiple reviewers to approve my code before merging

## Why do you want to make these changes?

- Python 3.6 is nearing EOL
- GitHub Actions have dropped Python 3.6 support ([source](https://github.com/actions/virtual-environments/issues/4060))
- Python 3.6 is broken on M1 Mac as numpy dropped 3.6 ages ago

## Which parts of the codebase do your changes affect?

None.

## How do your changes affect student or volunteer experience?

Python 3.6 is no longer tested on CI, so may affect users that use 7 year old versions of Python.

## Are your changes related to any existing issues or PRs? How so?

#762 does not pass CI, as Python 3.6 is no longer supported by GitHub actions.