### PR TITLE
Distinguish between blocking and non-blocking buzzes

### DIFF
--- a/j5/backends/console/sr/v4/power_board.py
+++ b/j5/backends/console/sr/v4/power_board.py
@@ -1,6 +1,7 @@
 """Console Backend for the SR V4 power board."""
 
 from datetime import timedelta
+from time import sleep
 from typing import Dict, Optional, Set, Type, cast
 
 from j5.backends import Backend
@@ -120,14 +121,20 @@ class SRV4PowerBoardConsoleBackend(
                              f"valid identifiers are "
                              f"{self._output_states.keys()}") from None
 
-    def buzz(self, identifier: int,
-             duration: timedelta, pitch: float) -> None:
+    def buzz(
+        self,
+        identifier: int,
+        duration: timedelta,
+        pitch: float,
+        blocking: bool,
+    ) -> None:
         """
         Queue a pitch to be played.
 
         :param identifier: piezo identifier to play pitch on.
         :param duration: duration of the tone.
         :param pitch: Pitch of the tone in Hz.
+        :param blocking: whether the code waits for the buzz
         :raises ValueError: invalid value for parameter.
         """
         if identifier != 0:
@@ -137,6 +144,10 @@ class SRV4PowerBoardConsoleBackend(
         if duration_ms > 65535:
             raise ValueError("Maximum piezo duration is 65535ms.")
         self._console.info(f"Buzzing at {pitch}Hz for {duration_ms}ms")
+
+        # If the buzz needs to block, wait for the correct time.
+        if blocking:
+            sleep(duration.total_seconds())
 
     def get_button_state(self, identifier: int) -> bool:
         """

--- a/j5/backends/hardware/sr/v4/power_board.py
+++ b/j5/backends/hardware/sr/v4/power_board.py
@@ -165,14 +165,20 @@ class SRV4PowerBoardHardwareBackend(
         current, = struct.unpack("<I", self._read(cmd))
         return cast(int, current) / 1000  # convert milliamps to amps
 
-    def buzz(self, identifier: int,
-             duration: timedelta, frequency: float) -> None:
+    def buzz(
+        self,
+        identifier: int,
+        duration: timedelta,
+        frequency: float,
+        blocking: bool,
+    ) -> None:
         """
         Queue a pitch to be played.
 
         :param identifier: piezo identifier to play pitch on.
         :param duration: duration of the tone.
         :param frequency: Pitch of the tone in Hz.
+        :param blocking: whether the code waits for the buzz
         :raises ValueError: invalid value for parameter.
         :raises CommunicationError: buzz commands sent too quickly
         :raises NotSupportedByHardwareError: unsupported pitch freq or length.
@@ -199,6 +205,10 @@ class SRV4PowerBoardHardwareBackend(
                     f"power board too quickly",
                 )
             raise
+
+        # If the buzz needs to block, wait for the correct time.
+        if blocking:
+            sleep(duration.total_seconds())
 
     def get_button_state(self, identifier: int) -> bool:
         """

--- a/tests/backends/console/sr/v4/test_power_board.py
+++ b/tests/backends/console/sr/v4/test_power_board.py
@@ -98,19 +98,19 @@ def test_backend_piezo_buzz() -> None:
 
     # Buzz a Note.
     backend._console.expects = "Buzzing at 2349.3Hz for 10000ms"  # type: ignore
-    backend.buzz(0, timedelta(seconds=10), Note.D7)
+    backend.buzz(0, timedelta(seconds=10), Note.D7, False)
 
     # Buzz a frequency
     backend._console.expects = "Buzzing at 100Hz for 10000ms"  # type: ignore
-    backend.buzz(0, timedelta(seconds=10), 100)
+    backend.buzz(0, timedelta(seconds=10), 100, False)
 
     # Buzz for too long.
     with pytest.raises(ValueError):
-        backend.buzz(0, timedelta(seconds=100), 10)
+        backend.buzz(0, timedelta(seconds=100), 10, False)
 
     # Test non-existent buzzer
     with pytest.raises(ValueError):
-        backend.buzz(1, timedelta(seconds=10), 0)
+        backend.buzz(1, timedelta(seconds=10), 0, False)
 
 
 def test_backend_get_button_state() -> None:

--- a/tests/backends/hardware/sr/v4/test_power_board.py
+++ b/tests/backends/hardware/sr/v4/test_power_board.py
@@ -324,22 +324,22 @@ def test_backend_piezo_buzz() -> None:
     backend = SRV4PowerBoardHardwareBackend(device)
 
     # Buzz a Note
-    backend.buzz(0, timedelta(seconds=10), Note.D7)
+    backend.buzz(0, timedelta(seconds=10), Note.D7, False)
 
     # Buzz a frequency
-    backend.buzz(0, timedelta(seconds=10), 100)
+    backend.buzz(0, timedelta(seconds=10), 100, False)
 
     # Buzz for too long.
     with pytest.raises(NotSupportedByHardwareError):
-        backend.buzz(0, timedelta(seconds=100), 10)
+        backend.buzz(0, timedelta(seconds=100), 10, False)
 
     # Buzz at a too high pitch.
     with pytest.raises(NotSupportedByHardwareError):
-        backend.buzz(0, timedelta(seconds=10), 65536)
+        backend.buzz(0, timedelta(seconds=10), 65536, False)
 
     # Test non-existent buzzer
     with pytest.raises(ValueError):
-        backend.buzz(1, timedelta(seconds=10), 0)
+        backend.buzz(1, timedelta(seconds=10), 0, False)
 
 
 def test_backend_get_button_state() -> None:

--- a/tests/boards/sr/v4/test_power_board.py
+++ b/tests/boards/sr/v4/test_power_board.py
@@ -61,7 +61,7 @@ class MockPowerBoardBackend(
         return 1.0
 
     def buzz(
-        self, identifier: int, duration: timedelta, pitch: Pitch,
+        self, identifier: int, duration: timedelta, pitch: Pitch, blocking: bool,
     ) -> None:
         """Buzz the buzzer."""
         pass

--- a/tests/components/test_piezo.py
+++ b/tests/components/test_piezo.py
@@ -11,7 +11,7 @@ class MockPiezoDriver(PiezoInterface):
     """A testing driver for the piezo."""
 
     def buzz(self, identifier: int,
-             duration: timedelta, frequency: float) -> None:
+             duration: timedelta, frequency: float, blocking: bool) -> None:
         """Queue a pitch to be played."""
         pass
 


### PR DESCRIPTION
Some devices with a piezo buzzer will buzz without blocking the code, which is quite useful.

However, sometimes with these devices it is useful to be able to buzz and then have the code wait for the buzz to finish. For example, when playing a tune.

Each `Piezo` component instance should have a default blocking state, which can then be overriden by users when `piezo.buzz` is called.

In the case that a backend does not support blocking buzzes, a sleep function should be added.

In the case that a backend does not support non-blocking buzzes, it should raise an exception or spawn a background thread for the buzz.

Fixes #160

## Checklist

- [ ] I have updated the relevant documentation
- [ ] I have added the `semver-major`, `semver-minor` or `semver-patch` label as appropriate
- [ ] I would like multiple reviewers to approve my code before merging

## Why do you want to make these changes?


## Which parts of the codebase do your changes affect?


## How do your changes affect student or volunteer experience?


## Are your changes related to any existing issues or PRs? How so?
