### PR TITLE
Handle USB Devices without serial numbers

### DIFF
--- a/j5/backends/hardware/__init__.py
+++ b/j5/backends/hardware/__init__.py
@@ -1,7 +1,15 @@
 """Backends for the hardware environment."""
 
+from j5.backends import CommunicationError
+
 from .env import NotSupportedByHardwareError
 
+
+class DeviceMissingSerialNumberError(CommunicationError):
+    """The device is missing a serial number."""
+
+
 __all__ = [
+    "DeviceMissingSerialNumberError",
     "NotSupportedByHardwareError",
 ]

--- a/j5/backends/hardware/j5/arduino.py
+++ b/j5/backends/hardware/j5/arduino.py
@@ -1,5 +1,6 @@
 """Base backend for Arduino Uno and its derivatives."""
 
+import logging
 from abc import abstractmethod
 from datetime import timedelta
 from threading import Lock
@@ -12,6 +13,8 @@ from j5.backends.hardware.j5.serial import SerialHardwareBackend
 from j5.boards import Board
 from j5.boards.arduino import ArduinoUno
 from j5.components import GPIOPinInterface, GPIOPinMode, LEDInterface
+
+LOGGER = logging.getLogger(__name__)
 
 
 class DigitalPinData:
@@ -65,12 +68,18 @@ class ArduinoHardwareBackend(
         # Get a list of boards from the ports.
         boards: Set[Board] = set()
         for port in filter(cls.is_arduino, ports):
-            boards.add(
-                cls.board(
-                    port.serial_number,
-                    cls(port.device),
-                ),
-            )
+            if port.serial_number is None:
+                LOGGER.warning(
+                    "Found Arduino Uno-like device without a serial number. "
+                    f"Ignoring device as it is incompatible: {port.usb_info()}",
+                )
+            else:
+                boards.add(
+                    cls.board(
+                        port.serial_number,
+                        cls(port.device),
+                    ),
+                )
 
         return boards
 

--- a/j5/backends/hardware/j5/raw_usb.py
+++ b/j5/backends/hardware/j5/raw_usb.py
@@ -13,6 +13,7 @@ from typing import Iterable, NamedTuple, Optional, Set, Union
 import usb
 
 from j5.backends import Backend, BackendMeta, CommunicationError
+from j5.backends.hardware import DeviceMissingSerialNumberError
 from j5.boards import Board
 
 # Stop the library from closing the USB connections before make_safe is called.
@@ -110,7 +111,7 @@ class RawUSBHardwareBackend(Backend, metaclass=BackendMeta):
         The serial number reported by the board.
 
         :returns: serial number reported by the board.
-        :raises CommunicationError: Found a USB Device with no serial number.
+        :raises DeviceMissingSerialNumberError: Found a USB Device with no serial number.
         :raises USBCommunicationError: Unable to query USB.
         """
         with self._lock:
@@ -118,7 +119,7 @@ class RawUSBHardwareBackend(Backend, metaclass=BackendMeta):
                 if self._usb_device.serial_number is not None:
                     return self._usb_device.serial_number
                 else:
-                    raise CommunicationError(
+                    raise DeviceMissingSerialNumberError(
                         f"Found a USB device ({self._usb_device.idVendor}, "
                         f"{self._usb_device.idProduct}) with no serial number",
                     )

--- a/j5/backends/hardware/j5/raw_usb.py
+++ b/j5/backends/hardware/j5/raw_usb.py
@@ -110,11 +110,18 @@ class RawUSBHardwareBackend(Backend, metaclass=BackendMeta):
         The serial number reported by the board.
 
         :returns: serial number reported by the board.
+        :raises CommunicationError: Found a USB Device with no serial number.
         :raises USBCommunicationError: Unable to query USB.
         """
         with self._lock:
             try:
-                return self._usb_device.serial_number
+                if self._usb_device.serial_number is not None:
+                    return self._usb_device.serial_number
+                else:
+                    raise CommunicationError(
+                        f"Found a USB device ({self._usb_device.idVendor}, "
+                        f"{self._usb_device.idProduct}) with no serial number",
+                    )
             except usb.core.USBError as e:
                 raise USBCommunicationError(e) from e
 

--- a/j5/backends/hardware/sr/v4/motor_board.py
+++ b/j5/backends/hardware/sr/v4/motor_board.py
@@ -6,6 +6,7 @@ from serial import SerialException, SerialTimeoutException
 from serial.tools.list_ports_common import ListPortInfo
 
 from j5.backends import Backend, CommunicationError
+from j5.backends.hardware import DeviceMissingSerialNumberError
 from j5.backends.hardware.j5.serial import SerialHardwareBackend
 from j5.boards import Board
 from j5.boards.sr.v4.motor_board import MotorBoard
@@ -45,7 +46,7 @@ class SRV4MotorBoardHardwareBackend(
         Discover boards that this backend can control.
 
         :returns: set of boards that this backend can control.
-        :raises CommunicationError: a motor board without a serial number was found.
+        :raises DeviceMissingSerialNumberError: a board without a serial number was found.
         """
         # Find all serial ports.
         ports = cls.get_comports()
@@ -54,7 +55,7 @@ class SRV4MotorBoardHardwareBackend(
         boards: Set[Board] = set()
         for port in filter(is_motor_board, ports):
             if port.serial_number is None:
-                raise CommunicationError(
+                raise DeviceMissingSerialNumberError(
                     "Found motor board-like device without serial number. "
                     f"The motor board is likely to be damaged: {port.usb_info()}",
                 )

--- a/stubs/serial/tools/list_ports_common.pyi
+++ b/stubs/serial/tools/list_ports_common.pyi
@@ -1,14 +1,16 @@
 """Type stubs for serial.tools.list_ports_common."""
+from typing import Optional
 
 class ListPortInfo:
     """Info collection base class for serial ports"""
 
     device: str
-    vid: int
-    pid: int
-    serial_number: str
-    manufacturer: str
-    product: str
+    vid: Optional[int]
+    pid: Optional[int]
+    serial_number: Optional[str]
+    manufacturer: Optional[str]
+    product: Optional[str]
 
 
     def __init__(self, device: str, skip_link_detection: bool = False) -> None: ...
+    def usb_info(self) -> str: ...

--- a/stubs/usb/core.pyi
+++ b/stubs/usb/core.pyi
@@ -10,9 +10,11 @@ from typing import Generator, Optional, Tuple, Union
 class Device:
 
     _langids: Tuple[int, ...]
+    idVendor: Optional[str]
+    idProduct: Optional[str]
 
     @property
-    def serial_number(self) -> str: ...
+    def serial_number(self) -> Optional[str]: ...
 
     def ctrl_transfer(
             self,

--- a/tests/backends/hardware/sr/v4/test_motor_board.py
+++ b/tests/backends/hardware/sr/v4/test_motor_board.py
@@ -1,5 +1,5 @@
 """Test the SR v4 motor board hardware backend and associated classes."""
-from typing import List, Type, cast
+from typing import List, Optional, Type, cast
 
 import pytest
 from serial import Serial
@@ -43,7 +43,7 @@ class MockListPortInfo:
     def __init__(
             self,
             device: str,
-            serial_number: str,
+            serial_number: Optional[str],
             vid: int = 0x403,
             pid: int = 0x6001,
             manufacturer: str = "Student Robotics",
@@ -55,6 +55,10 @@ class MockListPortInfo:
         self.pid = pid
         self.manufacturer = manufacturer
         self.product = product
+
+    def usb_info(self) -> str:
+        """Get a string containing information about the device."""
+        return "USB Information"
 
 
 def mock_comports(include_links: bool = False) -> List[MockListPortInfo]:
@@ -102,6 +106,17 @@ class MockMotorSerialBackend(SRV4MotorBoardHardwareBackend):
     def get_serial_class(self) -> Type[Serial]:
         """Get the serial class."""
         return MotorSerial  # type: ignore
+
+
+class MockMotorSerialBadSerialNumberBackend(SRV4MotorBoardHardwareBackend):
+    """Mock backend for testing."""
+
+    @classmethod
+    def get_comports(cls) -> List[ListPortInfo]:
+        """Get the comports."""
+        return [
+            MockListPortInfo("COM0", None),  # type: ignore
+        ]
 
 
 class MotorSerialBadWrite(MotorSerial):
@@ -162,6 +177,16 @@ def test_backend_discover() -> None:
     assert all(type(board) is MotorBoard for board in found_boards)
 
     assert all((int(board.serial_number[6:])) < 2 for board in found_boards)
+
+
+def test_backend_discover_missing_serial_number() -> None:
+    """Test we correctly handle motor boards without a serial number."""
+    with pytest.raises(CommunicationError) as e:
+        MockMotorSerialBadSerialNumberBackend.discover()
+    assert e.match(  # type: ignore
+        "Found motor board-like device without serial number. "
+        "The motor board is likely to be damaged: USB Information",
+    )
 
 
 def test_backend_send_command() -> None:

--- a/tests/backends/hardware/sr/v4/test_motor_board.py
+++ b/tests/backends/hardware/sr/v4/test_motor_board.py
@@ -6,6 +6,7 @@ from serial import Serial
 from serial.tools.list_ports_common import ListPortInfo
 
 from j5.backends import CommunicationError
+from j5.backends.hardware import DeviceMissingSerialNumberError
 from j5.backends.hardware.sr.v4.motor_board import (
     CMD_BOOTLOADER,
     CMD_MOTOR,
@@ -181,7 +182,7 @@ def test_backend_discover() -> None:
 
 def test_backend_discover_missing_serial_number() -> None:
     """Test we correctly handle motor boards without a serial number."""
-    with pytest.raises(CommunicationError) as e:
+    with pytest.raises(DeviceMissingSerialNumberError) as e:
         MockMotorSerialBadSerialNumberBackend.discover()
     assert e.match(  # type: ignore
         "Found motor board-like device without serial number. "


### PR DESCRIPTION
## Checklist

- [x] I have updated the relevant documentation
- [x] I have added the `semver-major`, `semver-minor` or `semver-patch` label as appropriate
- [ ] I would like multiple reviewers to approve my code before merging

## Why do you want to make these changes?

Fix #783 

## Which parts of the codebase do your changes affect?

Serial and USB discovery

## How do your changes affect student or volunteer experience?

This was a bug experienced by a team during SR2022. Due to limitations of how j5 works, we cannot fix it sadly. This prints a warning message or error if the device is known to always have a serial number.

## Are your changes related to any existing issues or PRs? How so?

Fixes #783 
