### PR TITLE
Add Board Feature Support and SR PBv4 5V + Brain Output Features

### DIFF
--- a/j5/backends/backend.py
+++ b/j5/backends/backend.py
@@ -134,3 +134,11 @@ class Backend(metaclass=BackendMeta):
     def firmware_version(self) -> Optional[str]:
         """The firmware version of the board."""
         raise NotImplementedError  # pragma: no cover
+
+    def get_features(self) -> Set['Board.AvailableFeatures']:
+        """
+        The set of features available on this backend.
+
+        :returns: The set of features available on this backend.
+        """
+        return set()

--- a/j5/backends/console/sr/v4/power_board.py
+++ b/j5/backends/console/sr/v4/power_board.py
@@ -43,7 +43,6 @@ class SRV4PowerBoardConsoleBackend(
         self._output_states: Dict[int, bool] = {
             output.value: False
             for output in PowerOutputPosition
-            if output is not PowerOutputPosition.FIVE_VOLT
         }
         self._led_states: Dict[int, bool] = {
             i: False
@@ -52,6 +51,14 @@ class SRV4PowerBoardConsoleBackend(
 
         # Setup console helper
         self._console = console_class(f"{self.board.__name__}({self._serial})")
+
+    def get_features(self) -> Set['Board.AvailableFeatures']:
+        """
+        The set of features available on this backend.
+
+        :returns: The set of features available on this backend.
+        """
+        return {PowerBoard.AvailableFeatures.REG_5V_CONTROL}
 
     @property
     def firmware_version(self) -> Optional[str]:

--- a/j5/backends/console/sr/v4/power_board.py
+++ b/j5/backends/console/sr/v4/power_board.py
@@ -43,6 +43,7 @@ class SRV4PowerBoardConsoleBackend(
         self._output_states: Dict[int, bool] = {
             output.value: False
             for output in PowerOutputPosition
+            if output is not PowerOutputPosition.FIVE_VOLT
         }
         self._led_states: Dict[int, bool] = {
             i: False

--- a/j5/backends/hardware/sr/v4/power_board.py
+++ b/j5/backends/hardware/sr/v4/power_board.py
@@ -30,6 +30,7 @@ from j5.components import (
 CMD_READ_OUTPUT: Mapping[int, ReadCommand] = {
     output.value: ReadCommand(output.value, 4)
     for output in PowerOutputPosition
+    if output != PowerOutputPosition.FIVE_VOLT
 }
 CMD_READ_5VRAIL = ReadCommand(6, 4)
 CMD_READ_BATTERY = ReadCommand(7, 8)
@@ -39,6 +40,7 @@ CMD_READ_FWVER = ReadCommand(9, 4)
 CMD_WRITE_OUTPUT: Mapping[int, WriteCommand] = {
     output.value: WriteCommand(output.value)
     for output in PowerOutputPosition
+    if output != PowerOutputPosition.FIVE_VOLT
 }
 CMD_WRITE_RUNLED = WriteCommand(6)
 CMD_WRITE_ERRORLED = WriteCommand(7)
@@ -85,6 +87,7 @@ class SRV4PowerBoardHardwareBackend(
         self._output_states: Dict[int, bool] = {
             output.value: False
             for output in PowerOutputPosition
+            if output is not PowerOutputPosition.FIVE_VOLT
         }
         self._led_states: Dict[int, bool] = {
             i: False

--- a/j5/boards/board.py
+++ b/j5/boards/board.py
@@ -1,6 +1,7 @@
 """The base classes for boards and group of boards."""
 
 import atexit
+import enum
 import logging
 import os
 import signal
@@ -34,6 +35,11 @@ class Board(metaclass=ABCMeta):
     # This is useful to know so that we can make them safe in a crash.
     BOARDS: Set['Board'] = set()
 
+    _backend: 'Backend'
+
+    class AvailableFeatures(str, enum.Enum):
+        """Features available on the board."""
+
     def __str__(self) -> str:
         """
         A string representation of this board.
@@ -61,6 +67,15 @@ class Board(metaclass=ABCMeta):
         :returns: string representation of the board.
         """
         return f"<{self.__class__.__name__} serial_number={self.serial_number}>"
+
+    @property
+    def features(self) -> Set['Board.AvailableFeatures']:
+        """
+        The set of features that are enabled on this board instance.
+
+        :returns: the features that are enabled on this board instance.
+        """
+        return self._backend.get_features()
 
     @property
     @abstractmethod

--- a/tests/backends/console/sr/v4/test_power_board.py
+++ b/tests/backends/console/sr/v4/test_power_board.py
@@ -15,7 +15,7 @@ def test_backend_initialisation() -> None:
     backend = SRV4PowerBoardConsoleBackend("Test")
     assert type(backend) is SRV4PowerBoardConsoleBackend
 
-    assert len(backend._output_states) == 6
+    assert len(backend._output_states) == 7  # 6 outputs + 5V
     assert not any(backend._output_states.values())  # Check initially all false.
 
     assert len(backend._led_states) == 2
@@ -51,11 +51,11 @@ def test_backend_get_power_output_enabled() -> None:
     """Test that we can read the enable status of a PowerOutput."""
     backend = SRV4PowerBoardConsoleBackend("TestBoard")
 
-    for i in range(0, 6):
+    for i in range(0, 7):
         assert not backend.get_power_output_enabled(i)
 
     with pytest.raises(ValueError):
-        backend.get_power_output_enabled(6)
+        backend.get_power_output_enabled(7)
 
 
 def test_backend_set_power_output_enabled() -> None:
@@ -65,13 +65,13 @@ def test_backend_set_power_output_enabled() -> None:
         console_class=MockConsole,
     )
 
-    for i in range(0, 6):
+    for i in range(0, 7):
         backend._console.expects = f"Setting output {i} to True"  # type: ignore
         backend.set_power_output_enabled(i, True)
 
     with pytest.raises(ValueError):
-        backend._console.expects = "Setting output 6 to True"  # type: ignore
-        backend.set_power_output_enabled(6, True)
+        backend._console.expects = "Setting output 7 to True"  # type: ignore
+        backend.set_power_output_enabled(7, True)
 
 
 def test_backend_get_power_output_current() -> None:
@@ -81,12 +81,12 @@ def test_backend_get_power_output_current() -> None:
         console_class=MockConsole,
     )
 
-    for i in range(0, 6):
+    for i in range(0, 7):
         backend._console.next_input = "1.2"  # type: ignore
         assert 1.2 == backend.get_power_output_current(i)
 
     with pytest.raises(ValueError):
-        backend.get_power_output_current(6)
+        backend.get_power_output_current(7)
 
 
 def test_backend_piezo_buzz() -> None:

--- a/tests/backends/hardware/sr/v4/test_power_board.py
+++ b/tests/backends/hardware/sr/v4/test_power_board.py
@@ -30,6 +30,8 @@ def test_cmd_read_output() -> None:
     assert len(CMD_READ_OUTPUT) == 6
 
     for pos in PowerOutputPosition:
+        if pos is PowerOutputPosition.FIVE_VOLT:
+            continue
         assert pos.value in CMD_READ_OUTPUT
         command = CMD_READ_OUTPUT[pos.value]
         assert pos.value == command.code
@@ -69,6 +71,8 @@ def test_cmd_write_output() -> None:
     assert len(CMD_WRITE_OUTPUT) == 6
 
     for pos in PowerOutputPosition:
+        if pos is PowerOutputPosition.FIVE_VOLT:
+            continue
         assert pos.value in CMD_WRITE_OUTPUT
         command = CMD_WRITE_OUTPUT[pos.value]
         assert pos.value == command.code


### PR DESCRIPTION
NB: This is the first major feature we've added to the j5 core in a long time, review is much appreciated!

## Checklist

- [x] I have updated the relevant documentation
- [x] I have added the `semver-major`, `semver-minor` or `semver-patch` label as appropriate
- [ ] I would like multiple reviewers to approve my code before merging

## Why do you want to make these changes?

Sometimes backends add or remove features from boards, we need to reflect that.

For example, only the new serial firmware for the power board supports controlling the 5V output, the old USB firmware is not capable of it.

## Which parts of the codebase do your changes affect?

All boards and backends. Backends and boards have no features by default.

## How do your changes affect student or volunteer experience?

Unblocks #816 

## Are your changes related to any existing issues or PRs? How so?

Unblocks #816 and closes #814
