### PR TITLE
Add Power Board compatibility backend

### DIFF
--- a/j5/backends/backend.py
+++ b/j5/backends/backend.py
@@ -82,6 +82,10 @@ class BackendMeta(ABCMeta):
         if getattr(cls, "__abstractmethods__", None):
             return cls
 
+        # Check if this is a discovery only Backend.
+        if len(cls.__bases__) <= 1 and cls.discover_only:  # type: ignore
+            return cls
+
         mcs._check_component_interfaces(cls)  # type: ignore
         _wrap_methods_with_logging(cls)  # type: ignore
 
@@ -117,6 +121,8 @@ class Backend(metaclass=BackendMeta):
     a physical component to be controlled by the abstract Component representation.
     """
 
+    discover_only = False
+
     @classmethod
     @abstractmethod
     def discover(cls) -> Set['Board']:
@@ -130,10 +136,13 @@ class Backend(metaclass=BackendMeta):
         raise NotImplementedError  # pragma: no cover
 
     @property
-    @abstractmethod
     def firmware_version(self) -> Optional[str]:
-        """The firmware version of the board."""
-        raise NotImplementedError  # pragma: no cover
+        """
+        The firmware version of the board.
+
+        :returns: None
+        """
+        return None
 
     def get_features(self) -> Set['Board.AvailableFeatures']:
         """

--- a/j5/backends/hardware/sr/v4/legacy/__init__.py
+++ b/j5/backends/hardware/sr/v4/legacy/__init__.py
@@ -1,0 +1,5 @@
+"""Backends for Student Robotics v4 Legacy Firmware."""
+
+from .power_board import SRV4LegacyPowerBoardHardwareBackend
+
+__all__ = ["SRV4LegacyPowerBoardHardwareBackend"]

--- a/j5/backends/hardware/sr/v4/legacy/power_board.py
+++ b/j5/backends/hardware/sr/v4/legacy/power_board.py
@@ -47,7 +47,7 @@ CMD_WRITE_ERRORLED = WriteCommand(7)
 CMD_WRITE_PIEZO = WriteCommand(8)
 
 
-class SRV4PowerBoardHardwareBackend(
+class SRV4LegacyPowerBoardHardwareBackend(
     RawUSBHardwareBackend,
     PowerOutputInterface,
     PiezoInterface,

--- a/j5/backends/hardware/sr/v4/legacy/power_board.py
+++ b/j5/backends/hardware/sr/v4/legacy/power_board.py
@@ -74,9 +74,12 @@ class SRV4LegacyPowerBoardHardwareBackend(
             raise USBCommunicationError(e) from e
 
         for device in device_list:
-            backend = cls(device)
-            board = PowerBoard(backend.serial, backend)
-            boards.add(cast(Board, board))
+            # Boards running legacy firmware only have 1 interface
+            # for the DFU updater.
+            if len(device.configurations()[0].interfaces()) == 1:  # type: ignore
+                backend = cls(device)
+                board = PowerBoard(backend.serial, backend)
+                boards.add(cast(Board, board))
         return boards
 
     def __init__(self, usb_device: usb.core.Device) -> None:

--- a/j5/backends/hardware/sr/v4/power_board.py
+++ b/j5/backends/hardware/sr/v4/power_board.py
@@ -1,0 +1,27 @@
+"""Discovery-only backend for legacy and serial drivers for Power Board."""
+from typing import Set
+
+from j5.backends import Backend
+from j5.boards import Board
+from j5.boards.sr.v4.power_board import PowerBoard
+
+from .legacy import SRV4LegacyPowerBoardHardwareBackend
+from .serial import SRV4SerialProtocolPowerBoardHardwareBackend
+
+
+class SRV4PowerBoardHardwareBackend(Backend):
+    """Discovery-only backend for legacy and serial drivers for Power Board."""
+
+    board = PowerBoard
+    discover_only = True
+
+    @classmethod
+    def discover(cls) -> Set[Board]:
+        """
+        Discover boards that this backend can control.
+
+        :returns: set of boards that this backend can control.
+        """
+        legacy_fw_boards = SRV4LegacyPowerBoardHardwareBackend.discover()
+        serial_fw_boards = SRV4SerialProtocolPowerBoardHardwareBackend.discover()
+        return legacy_fw_boards | serial_fw_boards

--- a/tests/backends/hardware/j5/test_raw_usb.py
+++ b/tests/backends/hardware/j5/test_raw_usb.py
@@ -13,7 +13,7 @@ from j5.backends.hardware.j5.raw_usb import (
 )
 from j5.boards import Board
 from j5.components import Component
-from tests.backends.hardware.sr.v4.test_power_board import MockUSBContext
+from tests.backends.hardware.sr.v4.legacy.test_power_board import MockUSBContext
 
 
 def test_read_command() -> None:

--- a/tests/backends/hardware/j5/test_raw_usb.py
+++ b/tests/backends/hardware/j5/test_raw_usb.py
@@ -13,7 +13,9 @@ from j5.backends.hardware.j5.raw_usb import (
 )
 from j5.boards import Board
 from j5.components import Component
-from tests.backends.hardware.sr.v4.legacy.test_power_board import MockUSBContext
+from tests.backends.hardware.sr.v4.legacy.test_power_board import (
+    MockUSBContext,
+)
 
 
 def test_read_command() -> None:

--- a/tests/backends/hardware/sr/v4/legacy/__init__.py
+++ b/tests/backends/hardware/sr/v4/legacy/__init__.py
@@ -1,0 +1,1 @@
+"""Test SR v4 legacy hardware backends."""

--- a/tests/backends/hardware/sr/v4/legacy/test_power_board.py
+++ b/tests/backends/hardware/sr/v4/legacy/test_power_board.py
@@ -1,10 +1,8 @@
 """Test the SR v4 PowerBoard backend and associated classes."""
 
-import re
 import struct
 from datetime import timedelta
-from typing import Iterable, Optional, Tuple, Union
-from unittest.mock import MagicMock
+from typing import Iterable, List, Optional, Tuple, Union
 
 import pytest
 import usb
@@ -106,15 +104,27 @@ class MockUSBContext:
         pass
 
 
+class MockUSBConfiguration:
+    """This class mocks the behavior of usb.core.Configuration."""
+
+    def interfaces(self) -> List[str]:
+        """Mock list of interfaces."""
+        return ["test"]
+
+
 class MockUSBPowerBoardDevice(usb.core.Device):
     """This class mocks the behaviour of a USB device for a Power Board."""
-
-    bNumConfigurations = 1
 
     def __init__(self, serial_number: str, fw_version: int = 3):
         self.serial = serial_number
         self.firmware_version = fw_version
         self._ctx = MockUSBContext()  # Used by PyUSB when cleaning up the device.
+
+    def configurations(self) -> Tuple[MockUSBConfiguration]:
+        """Get the configurations on the device."""
+        return (
+            MockUSBConfiguration(),
+        )
 
     @property
     def serial_number(self) -> str:

--- a/tests/backends/hardware/sr/v4/legacy/test_power_board.py
+++ b/tests/backends/hardware/sr/v4/legacy/test_power_board.py
@@ -1,15 +1,17 @@
 """Test the SR v4 PowerBoard backend and associated classes."""
 
+import re
 import struct
 from datetime import timedelta
-from typing import Iterable, Optional, Union
+from typing import Iterable, Optional, Tuple, Union
+from unittest.mock import MagicMock
 
 import pytest
 import usb
 
 from j5.backends.hardware import NotSupportedByHardwareError
 from j5.backends.hardware.j5.raw_usb import ReadCommand, WriteCommand
-from j5.backends.hardware.sr.v4.power_board import (
+from j5.backends.hardware.sr.v4.legacy.power_board import (
     CMD_READ_5VRAIL,
     CMD_READ_BATTERY,
     CMD_READ_BUTTON,
@@ -19,7 +21,7 @@ from j5.backends.hardware.sr.v4.power_board import (
     CMD_WRITE_OUTPUT,
     CMD_WRITE_PIEZO,
     CMD_WRITE_RUNLED,
-    SRV4PowerBoardHardwareBackend,
+    SRV4LegacyPowerBoardHardwareBackend,
 )
 from j5.boards.sr.v4.power_board import PowerBoard, PowerOutputPosition
 from j5.components.piezo import Note
@@ -106,6 +108,8 @@ class MockUSBContext:
 
 class MockUSBPowerBoardDevice(usb.core.Device):
     """This class mocks the behaviour of a USB device for a Power Board."""
+
+    bNumConfigurations = 1
 
     def __init__(self, serial_number: str, fw_version: int = 3):
         self.serial = serial_number
@@ -214,7 +218,7 @@ class MockUSBPowerBoardDevice(usb.core.Device):
         assert duration_ms >= 0
 
 
-class MockSRV4PowerBoardHardwareBackend(SRV4PowerBoardHardwareBackend):
+class MockSRV4LegacyPowerBoardHardwareBackend(SRV4LegacyPowerBoardHardwareBackend):
     """Mock class."""
 
     @classmethod
@@ -236,8 +240,8 @@ class MockSRV4PowerBoardHardwareBackend(SRV4PowerBoardHardwareBackend):
 def test_backend_initialisation() -> None:
     """Test that we can initialise a Backend."""
     device = MockUSBPowerBoardDevice("SERIAL0")
-    backend = SRV4PowerBoardHardwareBackend(device)
-    assert type(backend) is SRV4PowerBoardHardwareBackend
+    backend = SRV4LegacyPowerBoardHardwareBackend(device)
+    assert type(backend) is SRV4LegacyPowerBoardHardwareBackend
     assert backend._usb_device is device
 
     assert len(backend._output_states) == 6
@@ -249,7 +253,7 @@ def test_backend_initialisation() -> None:
 
 def test_backend_discover() -> None:
     """Test that the backend can discover boards."""
-    found_boards = MockSRV4PowerBoardHardwareBackend.discover()
+    found_boards = MockSRV4LegacyPowerBoardHardwareBackend.discover()
 
     assert len(found_boards) == 4
     assert all(type(board) is PowerBoard for board in found_boards)
@@ -258,7 +262,7 @@ def test_backend_discover() -> None:
 def test_backend_cleanup() -> None:
     """Test that the backend cleans things up properly."""
     device = MockUSBPowerBoardDevice("SERIAL0")
-    backend = SRV4PowerBoardHardwareBackend(device)
+    backend = SRV4LegacyPowerBoardHardwareBackend(device)
 
     del backend
 
@@ -266,7 +270,7 @@ def test_backend_cleanup() -> None:
 def test_backend_firmware_version() -> None:
     """Test that we can get the firmware version."""
     device = MockUSBPowerBoardDevice("SERIAL0")
-    backend = SRV4PowerBoardHardwareBackend(device)
+    backend = SRV4LegacyPowerBoardHardwareBackend(device)
 
     assert backend.firmware_version == "3"
 
@@ -275,13 +279,13 @@ def test_backend_bad_firmware_version() -> None:
     """Test that we can get the firmware version."""
     device = MockUSBPowerBoardDevice("SERIAL0", fw_version=2)
     with pytest.raises(NotImplementedError):
-        SRV4PowerBoardHardwareBackend(device)
+        SRV4LegacyPowerBoardHardwareBackend(device)
 
 
 def test_backend_serial_number() -> None:
     """Test that we can get the serial number."""
     device = MockUSBPowerBoardDevice("SERIAL0")
-    backend = SRV4PowerBoardHardwareBackend(device)
+    backend = SRV4LegacyPowerBoardHardwareBackend(device)
 
     assert backend.serial == "SERIAL0"
 
@@ -289,7 +293,7 @@ def test_backend_serial_number() -> None:
 def test_backend_get_power_output_enabled() -> None:
     """Test that we can read the enable status of a PowerOutput."""
     device = MockUSBPowerBoardDevice("SERIAL0")
-    backend = SRV4PowerBoardHardwareBackend(device)
+    backend = SRV4LegacyPowerBoardHardwareBackend(device)
 
     for i in range(0, 6):
         assert not backend.get_power_output_enabled(i)
@@ -301,7 +305,7 @@ def test_backend_get_power_output_enabled() -> None:
 def test_backend_set_power_output_enabled() -> None:
     """Test that we can read the enable status of a PowerOutput."""
     device = MockUSBPowerBoardDevice("SERIAL0")
-    backend = SRV4PowerBoardHardwareBackend(device)
+    backend = SRV4LegacyPowerBoardHardwareBackend(device)
 
     for i in range(0, 6):
         backend.set_power_output_enabled(i, True)
@@ -313,7 +317,7 @@ def test_backend_set_power_output_enabled() -> None:
 def test_backend_get_power_output_current() -> None:
     """Test that we can read the current on a PowerOutput."""
     device = MockUSBPowerBoardDevice("SERIAL0")
-    backend = SRV4PowerBoardHardwareBackend(device)
+    backend = SRV4LegacyPowerBoardHardwareBackend(device)
 
     for i in range(0, 6):
         assert 1.2 == backend.get_power_output_current(i)
@@ -325,7 +329,7 @@ def test_backend_get_power_output_current() -> None:
 def test_backend_piezo_buzz() -> None:
     """Test that we can buzz the Piezo."""
     device = MockUSBPowerBoardDevice("SERIAL0")
-    backend = SRV4PowerBoardHardwareBackend(device)
+    backend = SRV4LegacyPowerBoardHardwareBackend(device)
 
     # Buzz a Note
     backend.buzz(0, timedelta(seconds=10), Note.D7, False)
@@ -349,7 +353,7 @@ def test_backend_piezo_buzz() -> None:
 def test_backend_get_button_state() -> None:
     """Test that we can get the button state."""
     device = MockUSBPowerBoardDevice("SERIAL0")
-    backend = SRV4PowerBoardHardwareBackend(device)
+    backend = SRV4LegacyPowerBoardHardwareBackend(device)
 
     assert not backend.get_button_state(0)
 
@@ -360,7 +364,7 @@ def test_backend_get_button_state() -> None:
 def test_backend_get_battery_sensor_voltage() -> None:
     """Test that we can get the battery sensor voltage."""
     device = MockUSBPowerBoardDevice("SERIAL0")
-    backend = SRV4PowerBoardHardwareBackend(device)
+    backend = SRV4LegacyPowerBoardHardwareBackend(device)
 
     assert backend.get_battery_sensor_voltage(0) == 0.982
 
@@ -371,7 +375,7 @@ def test_backend_get_battery_sensor_voltage() -> None:
 def test_backend_get_battery_sensor_current() -> None:
     """Test that we can get the battery sensor current."""
     device = MockUSBPowerBoardDevice("SERIAL0")
-    backend = SRV4PowerBoardHardwareBackend(device)
+    backend = SRV4LegacyPowerBoardHardwareBackend(device)
 
     assert backend.get_battery_sensor_current(0) == 0.567
 
@@ -382,7 +386,7 @@ def test_backend_get_battery_sensor_current() -> None:
 def test_backend_get_led_states() -> None:
     """Get the LED states."""
     device = MockUSBPowerBoardDevice("SERIAL0")
-    backend = SRV4PowerBoardHardwareBackend(device)
+    backend = SRV4LegacyPowerBoardHardwareBackend(device)
 
     assert not any([backend.get_led_state(i) for i in [0, 1]])  # noqa: C407
 
@@ -393,7 +397,7 @@ def test_backend_get_led_states() -> None:
 def test_backend_set_led_states() -> None:
     """Set the LED states."""
     device = MockUSBPowerBoardDevice("SERIAL0")
-    backend = SRV4PowerBoardHardwareBackend(device)
+    backend = SRV4LegacyPowerBoardHardwareBackend(device)
 
     for i in [0, 1]:
         backend.set_led_state(i, True)

--- a/tests_hw/test_power_board.py
+++ b/tests_hw/test_power_board.py
@@ -7,7 +7,7 @@ from j5 import BaseRobot, BoardGroup
 from j5.backends.hardware.sr.v4.power_board import (
     SRV4PowerBoardHardwareBackend,
 )
-from j5.boards.sr.v4.power_board import PowerBoard, PowerOutputPosition
+from j5.boards.sr.v4.power_board import PowerBoard
 from j5.components.piezo import Note
 
 
@@ -37,27 +37,27 @@ if __name__ == '__main__':
     print(f"Battery voltage: {r.power_board.battery_sensor.voltage} V")
     print(f"Battery current: {r.power_board.battery_sensor.current} A")
 
-    for output in PowerOutputPosition:
-        print(f"Output {output} on.")
-        r.power_board.outputs[output].is_enabled = True
+    for output in r.power_board.outputs:
+        print(f"Output {output.identifier} on.")
+        output.is_enabled = True
         sleep(0.5)
 
-    for output in PowerOutputPosition:
-        print(f"Output {str(output)} current: {r.power_board.outputs[output].current} A")
+    for output in r.power_board.outputs:
+        print(f"Output {output.identifier} current: {output.current} A")
 
-    for output in PowerOutputPosition:
-        print(f"Output {output} off.")
-        r.power_board.outputs[output].is_enabled = False
+    for output in r.power_board.outputs:
+        print(f"Output {output.identifier} off.")
+        output.is_enabled = False
         sleep(0.5)
 
     for pitch in Note:
         print(f"Buzzing at pitch: {pitch}")
-        r.power_board.piezo.buzz(timedelta(seconds=0.1), pitch)
+        r.power_board.piezo.buzz(timedelta(seconds=0.1), pitch, blocking=True)
 
     for led in [r.power_board._run_led, r.power_board._error_led]:
-        print(f"LED {led} is on.")
+        print(f"LED {led.identifier} is on.")
         led.state = True
         sleep(0.5)
-        print(f"LED {led} is off.")
+        print(f"LED {led.identifier} is off.")
         led.state = False
         sleep(0.5)


### PR DESCRIPTION
- Move Power Board backend to legacy module
- Implement `discovery_only` backends to BackendMeta
- Implement Power Board Backend with auto protocol discovery

## Checklist

- [x] I have updated the relevant documentation
- [x] I have added the `semver-major`, `semver-minor` or `semver-patch` label as appropriate
- [ ] I would like multiple reviewers to approve my code before merging

## Why do you want to make these changes?

It's useful to be able to use the same backend to control power boards with both the old and new firmware.

## Which parts of the codebase do your changes affect?

SR Power Board backends.

## How do your changes affect student or volunteer experience?

n/a

## Are your changes related to any existing issues or PRs? How so?
