### PR TITLE
CI: Use `__token__` as username when pushing to PyPI

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -27,5 +27,6 @@ jobs:
         run: python tools/verify_git_version.py
       - name: Upload built artifacts to PyPI
         env:
-          POETRY_PYPI_TOKEN_PYPI: ${{secrets.PYPI_TOKEN}}
+          POETRY_HTTP_BASIC_PYPI_USERNAME: __token__
+          POETRY_HTTP_BASIC_PYPI_PASSWORD: ${{secrets.PYPI_TOKEN}}
         run: poetry publish --build


### PR DESCRIPTION
## Checklist

- [x] I have updated the relevant documentation
- [x] I have added the `semver-major`, `semver-minor` or `semver-patch` label as appropriate
- [ ] I would like multiple reviewers to approve my code before merging

## Why do you want to make these changes?
Because the CI workflow for publishing fails to publish to PyPI due to this change.

## Which parts of the codebase do your changes affect?
None.

## How do your changes affect student or volunteer experience?
N/A.

## Are your changes related to any existing issues or PRs? How so?
N/A.