### PR TITLE
Handle ruggeduino occasionally returning spurious bytes

### DIFF
--- a/j5/backends/hardware/j5/serial.py
+++ b/j5/backends/hardware/j5/serial.py
@@ -1,4 +1,5 @@
 """Abstract hardware backend implementation provided by j5 for serial comms."""
+import logging
 from abc import abstractmethod
 from datetime import timedelta
 from typing import List, Optional, Set, Type
@@ -92,7 +93,11 @@ class SerialHardwareBackend(Backend, metaclass=BackendMeta):
                 "Is it correctly powered?",
             )
 
-        ldata = bdata.decode('utf-8')
+        try:
+            ldata = bdata.decode('utf-8')
+        except UnicodeDecodeError as e:
+            logging.getLogger(__file__).error(f"{e} in {bdata}")
+            ldata = ''
         return ldata.rstrip()
 
     def read_serial_chars(self, size: int = 1) -> str:

--- a/j5/backends/hardware/j5/serial.py
+++ b/j5/backends/hardware/j5/serial.py
@@ -77,6 +77,7 @@ class SerialHardwareBackend(Backend, metaclass=BackendMeta):
         :param empty: Allow empty line.
         :returns: line read from serial port.
         :raises CommunicationError: serial error whilst reading line.
+        :raises UnicodeDecodeError: serial returned invalid unicode.
         """
         try:
             bdata = self._serial.readline()

--- a/j5/backends/hardware/j5/serial.py
+++ b/j5/backends/hardware/j5/serial.py
@@ -96,8 +96,11 @@ class SerialHardwareBackend(Backend, metaclass=BackendMeta):
         try:
             ldata = bdata.decode('utf-8')
         except UnicodeDecodeError as e:
-            logging.getLogger(__file__).error(f"{e} in {bdata!r}")
-            ldata = ''
+            if empty:
+                logging.getLogger(__file__).error(f"{e} in {bdata!r}")
+                ldata = ''
+            else:
+                raise
         return ldata.rstrip()
 
     def read_serial_chars(self, size: int = 1) -> str:

--- a/j5/backends/hardware/j5/serial.py
+++ b/j5/backends/hardware/j5/serial.py
@@ -96,7 +96,7 @@ class SerialHardwareBackend(Backend, metaclass=BackendMeta):
         try:
             ldata = bdata.decode('utf-8')
         except UnicodeDecodeError as e:
-            logging.getLogger(__file__).error(f"{e} in {bdata}")
+            logging.getLogger(__file__).error(f"{e} in {bdata!r}")
             ldata = ''
         return ldata.rstrip()
 

--- a/j5/backends/hardware/j5/serial.py
+++ b/j5/backends/hardware/j5/serial.py
@@ -99,9 +99,8 @@ class SerialHardwareBackend(Backend, metaclass=BackendMeta):
         except UnicodeDecodeError as e:
             if empty:
                 logging.getLogger(__file__).error(f"{e} in {bdata!r}")
-                ldata = ''
-            else:
-                raise
+                return ''
+            raise
         return ldata.rstrip()
 
     def read_serial_chars(self, size: int = 1) -> str:


### PR DESCRIPTION
## Checklist

- [ ] I have updated the relevant documentation
- [ ] I have added the `semver-major`, `semver-minor` or `semver-patch` label as appropriate
- [ ] I would like multiple reviewers to approve my code before merging

## Why do you want to make these changes?

The ruggeduino occasionally returns "\xFF" when first queried which can't be converted to unicode, so throws a UnicodeDecodeError during discovery.

## Which parts of the codebase do your changes affect?

Serial devices.

## How do your changes affect student or volunteer experience?


## Are your changes related to any existing issues or PRs? How so?
